### PR TITLE
using numpy.linalg.svd instead scipy

### DIFF
--- a/sumy/summarizers/lsa.py
+++ b/sumy/summarizers/lsa.py
@@ -10,7 +10,7 @@ except ImportError:
     numpy = None
 
 try:
-    from scipy.linalg import svd as singular_value_decomposition
+    from numpy.linalg import svd as singular_value_decomposition
 except ImportError:
     singular_value_decomposition = None
 from ._summarizer import AbstractSummarizer
@@ -47,9 +47,7 @@ class LsaSummarizer(AbstractSummarizer):
 
     def _ensure_dependecies_installed(self):
         if numpy is None:
-            raise ValueError("LSA summarizer requires NumPy & SciPy. Please, install them by command 'pip install numpy scipy'.")
-        elif singular_value_decomposition is None:
-            raise ValueError("LSA summarizer requires SciPy. Please, install it by command 'pip install scipy'.")
+            raise ValueError("LSA summarizer requires Numpy. Please, install them by command 'pip install numpy'.")
 
     def _create_dictionary(self, document):
         """Creates mapping key = word, value = row index"""

--- a/tests/test_summarizers/test_lsa.py
+++ b/tests/test_summarizers/test_lsa.py
@@ -28,16 +28,6 @@ class TestLsa(unittest.TestCase):
 
         lsa_module.numpy = numpy
 
-    def test_scipy_not_installed(self):
-        summarizer = LsaSummarizer()
-
-        scipy = lsa_module.singular_value_decomposition
-        lsa_module.singular_value_decomposition = None
-
-        self.assertRaises(ValueError, summarizer, build_document(), 10)
-
-        lsa_module.singular_value_decomposition = scipy
-
     def test_dictionary_without_stop_words(self):
         summarizer = LsaSummarizer()
         summarizer.stop_words = ["stop", "Halt", "SHUT", "HmMm"]


### PR DESCRIPTION
Hello,

There is SVD implementation in numpy.linalg (http://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.svd.html) too which can serve the purpose for the LSA algorithm.  I was recently trying to setup scipy on an aws image and was having hard time fixing issues with dependencies, whereas getting numpy to work has been a relatively easier process.

Shantanu
