### PR TITLE
Adding rouge

### DIFF
--- a/sumy/evaluation/__init__.py
+++ b/sumy/evaluation/__init__.py
@@ -6,3 +6,4 @@ from __future__ import division, print_function, unicode_literals
 
 from .coselection import f_score, precision, recall
 from .content_based import cosine_similarity, unit_overlap
+from .rouge import rouge_n, rouge_1, rouge_2, rouge_l_sentence_level, rouge_l_summary_level 

--- a/sumy/evaluation/__main__.py
+++ b/sumy/evaluation/__main__.py
@@ -45,6 +45,7 @@ from ..summarizers.text_rank import TextRankSummarizer
 from ..summarizers.lex_rank import LexRankSummarizer
 from ..nlp.stemmers import Stemmer
 from . import precision, recall, f_score, cosine_similarity, unit_overlap
+from . import rouge_1, rouge_2, rouge_l_sentence_level, rouge_l_summary_level 
 
 
 HEADERS = {
@@ -131,6 +132,10 @@ AVAILABLE_EVALUATIONS = (
     ("Cosine similarity (document)", True, evaluate_cosine_similarity),
     ("Unit overlap", False, evaluate_unit_overlap),
     ("Unit overlap (document)", True, evaluate_unit_overlap),
+    ("Rouge-1", False, rouge_1),
+    ("Rouge-2", False, rouge_2),
+    ("Rouge-L (Sentence Level)", False, rouge_l_sentence_level),
+    ("Rouge-L (Summary Level)", False, rouge_l_summary_level)
 )
 
 

--- a/sumy/evaluation/rouge.py
+++ b/sumy/evaluation/rouge.py
@@ -1,0 +1,261 @@
+# -*- coding: utf8 -*-
+
+from __future__ import absolute_import
+from __future__ import division, print_function, unicode_literals
+
+from ..models.dom import Sentence
+
+
+def _get_ngrams(n, text):
+	ngram_set = set()
+	text_length = len(text)
+	max_index_ngram_start = text_length - n
+	for i in range (max_index_ngram_start + 1):
+		ngram_set.add(tuple(text[i:i+n]))
+	return ngram_set
+
+
+def _split_into_words(sentences):
+	fullTextWords = []
+	for s in sentences:
+		if not isinstance(s, Sentence): 
+			raise (ValueError("Object in collection must be of type Sentence"))
+		fullTextWords.extend(s.words)
+	return fullTextWords
+
+
+def _get_word_ngrams(n, sentences):
+	assert (len(sentences) > 0)
+	assert (n > 0)
+
+	words = _split_into_words(sentences)
+	return _get_ngrams(n, words)
+
+
+def _get_index_of_lcs(x, y):
+	return len(x), len(y)
+
+def _len_lcs(x, y):
+	'''
+	Returns the length of the Longest Common Subsequence between sequences x
+	and y.
+	Source: http://www.algorithmist.com/index.php/Longest_Common_Subsequence
+	
+	:param x: sequence of words
+	:param y: sequence of words
+	:returns integer: Length of LCS between x and y
+	'''
+	table = _lcs(x, y)
+	n, m = _get_index_of_lcs(x, y)
+	return table[n, m]
+
+
+def _lcs (x, y):
+	'''
+	Computes the length of the longest common subsequence (lcs) between two
+	strings. The implementation below uses a DP programming algorithm and runs
+	in O(nm) time where n = len(x) and m = len(y).
+	Source: http://www.algorithmist.com/index.php/Longest_Common_Subsequence
+
+	:param x: collection of words
+	:param y: collection of words
+	:returns table: dictionary of coord and len lcs
+	'''
+
+	n, m = _get_index_of_lcs(x, y)
+	table = dict()
+	for i in range(n + 1):
+		for j in range (m + 1):
+			if i == 0 or j == 0:
+				table[i, j] = 0
+			elif x[i-1] == y[j-1]:
+				table[i, j] = table[i-1, j-1] + 1
+			else:
+				table[i, j] = max(table[i-1, j], table[i, j-1])
+	return table
+
+
+def _recon_lcs(x, y):
+	'''
+	Returns the Longest Subsequence between x and y.
+	Source: http://www.algorithmist.com/index.php/Longest_Common_Subsequence
+
+	:param x: sequence of words
+	:param y: sequence of words
+	:returns sequence: LCS of x and y
+	'''
+	i, j = _get_index_of_lcs(x, y)
+	table = _lcs(x, y)
+	def _recon (i, j):
+		if i == 0 or j == 0:
+			return []
+		elif x[i-1] == y[j-1]:
+			return _recon(i-1, j-1) + [(x[i-1], i)]
+		elif table[i-1, j] > table[i, j-1]:
+			return _recon(i-1, j)
+		else:
+			return _recon(i, j-1)
+	recon_tuple = tuple(map(lambda x: x[0], _recon(i, j)))
+	return recon_tuple
+
+
+def rouge_n(evaluated_sentences, reference_sentences, n=2):
+	"""
+	Computes ROUGE-N of two text collections of sentences.
+	Sourece: http://research.microsoft.com/en-us/um/people/cyl/download/
+	papers/rouge-working-note-v1.3.1.pdf
+
+	TODO: Implement such that it can use multiple reference
+		  summaries 
+
+	:param evaluated_sentences: 
+		The sentences that have been picked by the summarizer
+	:param reference_sentences:
+		The sentences from the referene set
+	:param n: Size of ngram.  Defaults to 2.
+	:returns: 
+		float 0 <= ROUGE-N <= 1, where 0 means no overlap and 1 means
+		exactly the same.
+	:raises ValueError: raises exception if a param has len <= 0
+	"""
+
+	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
+		raise (ValueError("Collections must contain at least 1 sentence."))
+
+	evaluated_ngrams = _get_word_ngrams(n, evaluated_sentences)
+	reference_ngrams = _get_word_ngrams(n, reference_sentences)
+	reference_count = len(reference_ngrams)
+
+	# Gets the overlapping ngrams between evaluated and reference
+	overlapping_ngrams = evaluated_ngrams.intersection(reference_ngrams)
+	overlapping_count = len(overlapping_ngrams)
+
+	return overlapping_count / reference_count
+
+
+def rouge_1(evaluated_sentences, reference_sentences):
+	'''
+	Rouge-N where N=1.  This is a commonly used metric.
+	'''
+	return rouge_n(evaluated_sentences, reference_sentences, 1)
+
+
+def rouge_2(evaluated_sentences, reference_sentences):
+	'''
+	Rouge-N where N=2.  This is a commonly used metric.
+	'''
+	return rouge_n(evaluated_sentences, reference_sentences, 2)
+
+
+def _union_lcs(evaluated_sentences, reference_sentences):
+	'''
+
+	'''
+	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
+		raise (ValueError("Collections must contain at least 1 sentence."))
+
+	union_lcs_across_ref = 0
+	for ref_s in reference_sentences:
+		lcs_union = set()
+		reference_words = _split_into_words([ref_s])
+		combined_lcs_count = 0	
+		for eval_s in evaluated_sentences:
+			evaluated_words = _split_into_words([eval_s])
+			lcs = set(_recon_lcs(reference_words, evaluated_words))
+			combined_lcs_count += len(lcs)
+			lcs_union = lcs_union.union(lcs)
+	
+		union_lcs_count = len(lcs_union)
+		union_lcs_across_ref += union_lcs_count / combined_lcs_count
+	return union_lcs_across_ref
+
+def _f_lcs(llcs, m, n):
+	'''
+	Computes the LCS-based F-measure score
+	Source: http://research.microsoft.com/en-us/um/people/cyl/download/papers/
+	rouge-working-note-v1.3.1.pdf
+	
+	:param llcs: Length of LCS
+	:param m: number of words in reference summary 
+	:param n: number of words in candidate summary
+	:returns float: LCS-based F-measure score
+	'''
+	r_lcs = llcs / m
+	p_lcs = llcs / n
+	beta = p_lcs / r_lcs
+	num = (1 + (beta ** 2)) * r_lcs * p_lcs 
+	denom = r_lcs + ((beta ** 2) * p_lcs)
+	return num / denom
+
+def rouge_l_sentence_level(evaluated_sentences, reference_sentences):
+	"""
+	Computes ROUGE-L (sentence level) of two text collections of sentences.
+	http://research.microsoft.com/en-us/um/people/cyl/download/papers/
+	rouge-working-note-v1.3.1.pdf
+	
+	Calculated according to:
+	R_lcs = LCS(X,Y)/m
+	P_lcs = LCS(X,Y)/n
+	F_lcs = ((1 + beta^2)*R_lcs*P_lcs) / (R_lcs + (beta^2) * P_lcs)
+
+	where:
+	X = reference summary
+	Y = Candidate summary
+	m = length of reference summary
+	n = length of candidate summary
+
+	:param evaluated_sentences: 
+		The sentences that have been picked by the summarizer
+	:param reference_sentences:
+		The sentences from the referene set
+	:returns float: F_lcs
+	:raises ValueError: raises exception if a param has len <= 0
+	"""
+	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
+		raise (ValueError("Collections must contain at least 1 sentence."))
+	reference_words = _split_into_words(reference_sentences)
+	evaluated_words = _split_into_words(evaluated_sentences)
+	m = len(reference_words)
+	n = len(evaluated_words)
+	lcs = _len_lcs(evaluated_words, reference_words)
+	return _f_lcs(lcs, m, n)
+
+
+def rouge_l_summary_level(evaluated_sentences, reference_sentences):
+	"""
+	Computes ROUGE-L (summary level) of two text collections of sentences.
+	http://research.microsoft.com/en-us/um/people/cyl/download/papers/
+	rouge-working-note-v1.3.1.pdf
+
+	Calculated according to:
+	R_lcs = SUM(1, u)[LCS<union>(r_i,C)]/m
+	P_lcs = SUM(1, u)[LCS<union>(r_i,C)]/n
+	F_lcs = ((1 + beta^2)*R_lcs*P_lcs) / (R_lcs + (beta^2) * P_lcs)
+
+	where:
+	SUM(i,u) = SUM from i through u
+	u = number of sentences in reference summary
+	C = Candidate summary made up of v sentences
+	m = number of words in reference summary
+	n = number of words in candidate summary
+
+	:param evaluated_sentences: 
+		The sentences that have been picked by the summarizer
+	:param reference_sentences:
+		The sentences from the referene set
+	:returns float: F_lcs
+	:raises ValueError: raises exception if a param has len <= 0
+
+	"""
+	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
+		raise (ValueError("Collections must contain at least 1 sentence."))
+
+	# total number of words in reference sentences
+	m = len(_split_into_words(reference_sentences))
+	
+	# total number of words in evaluated sentences
+	n = len(_split_into_words(evaluated_sentences))
+
+	union_lcs = _union_lcs(evaluated_sentences, reference_sentences)
+	return _f_lcs(union_lcs, m, n)
+

--- a/sumy/evaluation/rouge.py
+++ b/sumy/evaluation/rouge.py
@@ -199,29 +199,6 @@ def rouge_l_sentence_level(evaluated_sentences, reference_sentences):
 	return _f_lcs(lcs, m, n)
 
 
-
-# def _union_lcs(evaluated_sentences, reference_sentences):
-# 	'''
-# 	LCS score of the union longest common subsequence between reference sentence
-# 	and candidate summary.
-# 	'''
-# 	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
-# 		raise (ValueError("Collections must contain at least 1 sentence."))
-
-# 	union_lcs_sum_across_all_references = 0
-# 	for ref_s in reference_sentences:
-# 		lcs_union = set()
-# 		reference_words = _split_into_words([ref_s])
-# 		combined_lcs_count = 0	
-# 		for eval_s in evaluated_sentences:
-# 			evaluated_words = _split_into_words([eval_s])
-# 			lcs = set(_recon_lcs(reference_words, evaluated_words))
-# 			combined_lcs_count += len(lcs)
-# 			lcs_union = lcs_union.union(lcs)
-	
-# 		union_lcs_count = len(lcs_union)
-# 		union_lcs_sum_across_all_references += union_lcs_count / combined_lcs_count
-# 	return union_lcs_sum_across_all_references
 def _union_lcs(evaluated_sentences, reference_sentence):
 	'''
 	Returns LCS_u(r_i, C) which is the LCS score of the union longest common subsequence 
@@ -247,6 +224,7 @@ def _union_lcs(evaluated_sentences, reference_sentence):
 	union_lcs_count = len(lcs_union)
 	union_lcs_value = union_lcs_count / combined_lcs_length
 	return union_lcs_value
+	
 
 def rouge_l_summary_level(evaluated_sentences, reference_sentences):
 	"""

--- a/sumy/evaluation/rouge.py
+++ b/sumy/evaluation/rouge.py
@@ -35,6 +35,7 @@ def _get_word_ngrams(n, sentences):
 def _get_index_of_lcs(x, y):
 	return len(x), len(y)
 
+
 def _len_lcs(x, y):
 	'''
 	Returns the length of the Longest Common Subsequence between sequences x
@@ -61,7 +62,6 @@ def _lcs (x, y):
 	:param y: collection of words
 	:returns table: dictionary of coord and len lcs
 	'''
-
 	n, m = _get_index_of_lcs(x, y)
 	table = dict()
 	for i in range(n + 1):
@@ -105,9 +105,6 @@ def rouge_n(evaluated_sentences, reference_sentences, n=2):
 	Sourece: http://research.microsoft.com/en-us/um/people/cyl/download/
 	papers/rouge-working-note-v1.3.1.pdf
 
-	TODO: Implement such that it can use multiple reference
-		  summaries 
-
 	:param evaluated_sentences: 
 		The sentences that have been picked by the summarizer
 	:param reference_sentences:
@@ -118,7 +115,6 @@ def rouge_n(evaluated_sentences, reference_sentences, n=2):
 		exactly the same.
 	:raises ValueError: raises exception if a param has len <= 0
 	"""
-
 	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
 		raise (ValueError("Collections must contain at least 1 sentence."))
 
@@ -136,6 +132,14 @@ def rouge_n(evaluated_sentences, reference_sentences, n=2):
 def rouge_1(evaluated_sentences, reference_sentences):
 	'''
 	Rouge-N where N=1.  This is a commonly used metric.
+
+	:param evaluated_sentences: 
+		The sentences that have been picked by the summarizer
+	:param reference_sentences:
+		The sentences from the referene set
+	:returns: 
+		float 0 <= ROUGE-N <= 1, where 0 means no overlap and 1 means
+		exactly the same.
 	'''
 	return rouge_n(evaluated_sentences, reference_sentences, 1)
 
@@ -143,6 +147,14 @@ def rouge_1(evaluated_sentences, reference_sentences):
 def rouge_2(evaluated_sentences, reference_sentences):
 	'''
 	Rouge-N where N=2.  This is a commonly used metric.
+
+	:param evaluated_sentences: 
+		The sentences that have been picked by the summarizer
+	:param reference_sentences:
+		The sentences from the referene set
+	:returns: 
+		float 0 <= ROUGE-N <= 1, where 0 means no overlap and 1 means
+		exactly the same.
 	'''
 	return rouge_n(evaluated_sentences, reference_sentences, 2)
 
@@ -164,6 +176,7 @@ def _f_lcs(llcs, m, n):
 	num = (1 + (beta ** 2)) * r_lcs * p_lcs 
 	denom = r_lcs + ((beta ** 2) * p_lcs)
 	return num / denom
+
 
 def rouge_l_sentence_level(evaluated_sentences, reference_sentences):
 	"""
@@ -208,6 +221,13 @@ def _union_lcs(evaluated_sentences, reference_sentence):
 	“w1 w2” and the longest common subsequence of r_i and c2 is “w1 w3 w5”. The 
 	union longest common subsequence of r_i, c1, and c2 is “w1 w2 w3 w5” and 
 	LCS_u(r_i, C) = 4/5.
+
+	:param evaluated_sentences: 
+		The sentences that have been picked by the summarizer
+	:param reference_sentence:
+		One of the sentences in the reference summaries
+	:returns float: LCS_u(r_i, C)
+	:raises ValueError: raises exception if a param has len <= 0
 	'''
 	if len(evaluated_sentences) <= 0: 
 		raise (ValueError("Collections must contain at least 1 sentence."))
@@ -224,7 +244,7 @@ def _union_lcs(evaluated_sentences, reference_sentence):
 	union_lcs_count = len(lcs_union)
 	union_lcs_value = union_lcs_count / combined_lcs_length
 	return union_lcs_value
-	
+
 
 def rouge_l_summary_level(evaluated_sentences, reference_sentences):
 	"""
@@ -250,7 +270,6 @@ def rouge_l_summary_level(evaluated_sentences, reference_sentences):
 		The sentences from the referene set
 	:returns float: F_lcs
 	:raises ValueError: raises exception if a param has len <= 0
-
 	"""
 	if len(evaluated_sentences) <= 0 or len(reference_sentences) <= 0: 
 		raise (ValueError("Collections must contain at least 1 sentence."))

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -297,7 +297,7 @@ class TestRougeEvaluation(unittest.TestCase):
         candidate_text = "one two six seven eight. one three eight nine five."
         candidates = PlaintextParser(candidate_text, Tokenizer("english")).document.sentences
 
-        self.assertAlmostEqual(_union_lcs(candidates, reference),  4/5)
+        self.assertAlmostEqual(_union_lcs(candidates, reference[0]),  4/5)
 
     def test_rouge_l_summary_level(self):
         pass

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -300,4 +300,9 @@ class TestRougeEvaluation(unittest.TestCase):
         self.assertAlmostEqual(_union_lcs(candidates, reference[0]),  4/5)
 
     def test_rouge_l_summary_level(self):
-        pass
+        reference_text = "one two three four five. one two three four five."
+        reference = PlaintextParser(reference_text, Tokenizer("english")).document.sentences
+
+        candidate_text = "one two six seven eight. one three eight nine five."
+        candidates = PlaintextParser(candidate_text, Tokenizer("english")).document.sentences
+        rouge_l_summary_level(candidates, reference)

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -6,10 +6,13 @@ from __future__ import division, print_function, unicode_literals
 import unittest
 
 from sumy.nlp.tokenizers import Tokenizer
+from sumy.parsers.plaintext import PlaintextParser
+from sumy.models.dom._sentence import Sentence
 from sumy.models import TfDocumentModel
 from sumy.evaluation import precision, recall, f_score
 from sumy.evaluation import cosine_similarity, unit_overlap
-
+from sumy.evaluation import rouge_n, rouge_l_sentence_level, rouge_l_summary_level 
+from sumy.evaluation.rouge import _get_ngrams, _split_into_words, _get_word_ngrams, _len_lcs, _recon_lcs, _union_lcs
 
 class TestCoselectionEvaluation(unittest.TestCase):
     def test_precision_empty_evaluated(self):
@@ -195,3 +198,106 @@ class TestContentBasedEvaluation(unittest.TestCase):
             tokenizer)
 
         self.assertAlmostEqual(unit_overlap(model1, model2), 1/3)
+
+
+class TestRougeEvaluation(unittest.TestCase):
+    def test_get_ngrams(self):
+        self.assertTrue(not _get_ngrams(3, ""))
+
+        correct_ngrams = [("t", "e"), ("e", "s"), ("s", "t"), 
+                          ("t", "i"), ("i", "n"), ("n", "g")]
+        found_ngrams = _get_ngrams(2, "testing")
+        self.assertEqual(len(correct_ngrams), len(found_ngrams))
+        for ngram in correct_ngrams:
+            self.assertTrue(ngram in found_ngrams)        
+
+    def test_split_into_words(self):
+        sentences1 = PlaintextParser.from_string("One, two two. Two. Three.", 
+            Tokenizer("english")).document.sentences
+        self.assertEqual(["One", "two", "two", "Two", "Three"], 
+            _split_into_words(sentences1))
+        
+        sentences2 = PlaintextParser.from_string("two two. Two. Three.", 
+            Tokenizer("english")).document.sentences
+        self.assertEqual(["two", "two", "Two", "Three"], 
+            _split_into_words(sentences2))
+
+    def test_get_word_ngrams(self):
+        sentences = PlaintextParser.from_string("This is a test.", 
+            Tokenizer("english")).document.sentences
+        correct_ngrams = [("This", "is"), ("is", "a"), ("a", "test")]
+        found_ngrams = _get_word_ngrams(2, sentences)
+        for ngram in correct_ngrams:
+            self.assertTrue(ngram in found_ngrams)      
+
+    def test_len_lcs(self):
+        self.assertEqual(_len_lcs("1234", "1224533324"), 4)
+        self.assertEqual(_len_lcs("thisisatest", "testing123testing"), 7)
+        
+
+    def test_recon_lcs(self):
+        self.assertEqual(_recon_lcs("1234", "1224533324"), ("1", "2", "3", "4"))
+        self.assertEqual(_recon_lcs("thisisatest", "testing123testing"), 
+            ("t", "s", "i", "t", "e", "s", "t"))
+
+
+    def test_rouge_n(self):
+        candidate_text = "pulses may ease schizophrenic voices"
+        candidate = PlaintextParser(candidate_text, Tokenizer("english")).document.sentences
+
+        reference1_text = "magnetic pulse series sent through brain may ease schizophrenic voices"
+        reference1 = PlaintextParser(reference1_text, Tokenizer("english")).document.sentences
+
+        reference2_text = "yale finds magnetic stimulation some relief to schizophrenics imaginary voices";
+
+        reference2 = PlaintextParser.from_string(reference2_text, 
+            Tokenizer("english")).document.sentences
+
+        self.assertAlmostEqual(rouge_n(candidate, reference1, 1),  4/10)
+        self.assertAlmostEqual(rouge_n(candidate, reference2, 1),  1/10)
+
+        self.assertAlmostEqual(rouge_n(candidate, reference1, 2),  3/9)
+        self.assertAlmostEqual(rouge_n(candidate, reference2, 2),  0/9)
+
+        self.assertAlmostEqual(rouge_n(candidate, reference1, 3),  2/8)
+        self.assertAlmostEqual(rouge_n(candidate, reference2, 3),  0/8)
+
+        self.assertAlmostEqual(rouge_n(candidate, reference1, 4),  1/7)
+        self.assertAlmostEqual(rouge_n(candidate, reference2, 4),  0/7)
+
+        # These tests will apply when multiple reference summaries can be input
+        # self.assertAlmostEqual(rouge_n(candidate, [reference1, reference2], 1),  5/20)
+        # self.assertAlmostEqual(rouge_n(candidate, [reference1, reference2], 2),  3/18)
+        # self.assertAlmostEqual(rouge_n(candidate, [reference1, reference2], 3),  2/16)
+        # self.assertAlmostEqual(rouge_n(candidate, [reference1, reference2], 4),  1/14)
+
+    
+    def test_rouge_l_sentence_level(self):
+        reference_text = "police killed the gunman"
+        reference = PlaintextParser(reference_text, Tokenizer("english")).document.sentences
+
+        candidate1_text = "police kill the gunman"
+        candidate1 = PlaintextParser(candidate1_text, Tokenizer("english")).document.sentences
+        
+        candidate2_text = "the gunman kill police"
+        candidate2 = PlaintextParser(candidate2_text, Tokenizer("english")).document.sentences
+    
+        candidate3_text = "the gunman police killed"
+        candidate3 = PlaintextParser(candidate3_text, Tokenizer("english")).document.sentences
+    
+        self.assertAlmostEqual(rouge_l_sentence_level(candidate1, reference),  3/4)
+        self.assertAlmostEqual(rouge_l_sentence_level(candidate2, reference),  2/4)
+        self.assertAlmostEqual(rouge_l_sentence_level(candidate2, reference),  2/4)
+
+
+    def test_union_lcs(self):
+        reference_text = "one two three four five"
+        reference = PlaintextParser(reference_text, Tokenizer("english")).document.sentences
+
+        candidate_text = "one two six seven eight. one three eight nine five."
+        candidates = PlaintextParser(candidate_text, Tokenizer("english")).document.sentences
+
+        self.assertAlmostEqual(_union_lcs(candidates, reference),  4/5)
+
+    def test_rouge_l_summary_level(self):
+        pass


### PR DESCRIPTION
This PR adds ROUGE-N (specifically ROUGE-1 and ROUGE-2) , ROUGE-L (Sentence Level), and ROUGE-L (Summary Level) evaluations.  Source: http://www.aclweb.org/anthology/W04-1013

Normally ROUGE evaluations are capable of supporting evaluations across multiple reference summaries (using a jack-knifing procedure) but since the current evaluation framework only supports evaluating based off of a single reference summary, this ability has been omitted.