### PR TITLE
Add kl sum

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Simple library and command line utility for extracting summary from HTML pages o
 - **LexRank** - Unsupervised approach inspired by algorithms PageRank and HITS, `reference <http://tangra.si.umich.edu/~radev/lexrank/lexrank.pdf>`_
 - **TextRank** - some sort of combination of a few resources that I found on the internet. I really don't remember the sources. Probably `Wikipedia <https://en.wikipedia.org/wiki/Automatic_summarization#Unsupervised_approaches:_TextRank_and_LexRank>`_ and some papers in 1st page of Google :)
 - **SumBasic** - Method that is often used as a baseline in the literature.  Source: `Read about SumBasic <http://www.cis.upenn.edu/~nenkova/papers/ipm.pdf>`_
+- **KL-Sum** - Method that greedily adds sentences to a summary so long as it decreases the KL Divergence. Source: `Read about KL-Sum <http://www.aclweb.org/anthology/N09-1041>`_
 
 Here are some other summarizers:
 

--- a/sumy/__main__.py
+++ b/sumy/__main__.py
@@ -4,12 +4,9 @@
 Sumy - automatic text summarizer.
 
 Usage:
-    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>]
-    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --url=<url>
-    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --file=<file_path>
-    sumy (luhn | edmundson | lsa | text-rank | lex-rank | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>]
-    sumy (luhn | edmundson | lsa | text-rank | lex-rank | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --url=<url>
-    sumy (luhn | edmundson | lsa | text-rank | lex-rank | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --file=<file_path>
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>]
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --url=<url>
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --file=<file_path>
     sumy --version
     sumy --help
 

--- a/sumy/__main__.py
+++ b/sumy/__main__.py
@@ -7,6 +7,9 @@ Usage:
     sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>]
     sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --url=<url>
     sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --file=<file_path>
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>]
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --url=<url>
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --file=<file_path>
     sumy --version
     sumy --help
 
@@ -42,6 +45,7 @@ from .summarizers.lsa import LsaSummarizer
 from .summarizers.text_rank import TextRankSummarizer
 from .summarizers.lex_rank import LexRankSummarizer
 from .summarizers.sum_basic import SumBasicSummarizer
+from .summarizers.kl import KLSummarizer
 from .nlp.stemmers import Stemmer
 
 HEADERS = {
@@ -59,6 +63,7 @@ AVAILABLE_METHODS = {
     "text-rank": TextRankSummarizer,
     "lex-rank": LexRankSummarizer,
     "sum-basic": SumBasicSummarizer,
+    "kl": KLSummarizer,
 }
 
 

--- a/sumy/evaluation/__main__.py
+++ b/sumy/evaluation/__main__.py
@@ -44,6 +44,7 @@ from ..summarizers.lsa import LsaSummarizer
 from ..summarizers.text_rank import TextRankSummarizer
 from ..summarizers.lex_rank import LexRankSummarizer
 from ..summarizers.sum_basic import SumBasicSummarizer
+from ..summarizers.kl import KLSummarizer
 from ..nlp.stemmers import Stemmer
 from . import precision, recall, f_score, cosine_similarity, unit_overlap
 from . import rouge_1, rouge_2, rouge_l_sentence_level, rouge_l_summary_level 
@@ -106,6 +107,13 @@ def build_sum_basic(parser, language):
     return summarizer
 
 
+def build_kl(parser, language):
+    summarizer = KLSummarizer(Stemmer(language))
+    summarizer.stop_words = get_stop_words(language)
+
+    return summarizer
+
+
 def evaluate_cosine_similarity(evaluated_sentences, reference_sentences):
     evaluated_words = tuple(chain(*(s.words for s in evaluated_sentences)))
     reference_words = tuple(chain(*(s.words for s in reference_sentences)))
@@ -132,7 +140,9 @@ AVAILABLE_METHODS = {
     "text-rank": build_text_rank,
     "lex-rank": build_lex_rank,
     "sum-basic": build_sum_basic,
+    "kl": build_kl,
 }
+
 AVAILABLE_EVALUATIONS = (
     ("Precision", False, precision),
     ("Recall", False, recall),

--- a/sumy/evaluation/__main__.py
+++ b/sumy/evaluation/__main__.py
@@ -4,9 +4,9 @@
 Sumy - evaluation of automatic text summary.
 
 Usage:
-    sumy_eval (random | luhn | edmundson | lsa | text-rank | lex-rank) <reference_summary> [--length=<length>] [--language=<lang>]
-    sumy_eval (random | luhn | edmundson | lsa | text-rank | lex-rank) <reference_summary> [--length=<length>] [--language=<lang>] --url=<url>
-    sumy_eval (random | luhn | edmundson | lsa | text-rank | lex-rank) <reference_summary> [--length=<length>] [--language=<lang>] --file=<file_path> --format=<file_format>
+    sumy_eval (random | luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) <reference_summary> [--length=<length>] [--language=<lang>]
+    sumy_eval (random | luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) <reference_summary> [--length=<length>] [--language=<lang>] --url=<url>
+    sumy_eval (random | luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) <reference_summary> [--length=<length>] [--language=<lang>] --file=<file_path> --format=<file_format>
     sumy_eval --version
     sumy_eval --help
 

--- a/sumy/summarizers/kl.py
+++ b/sumy/summarizers/kl.py
@@ -1,0 +1,140 @@
+# -*- coding: utf8 -*-
+
+from __future__ import absolute_import
+from __future__ import division, print_function, unicode_literals
+import math
+
+from ._summarizer import AbstractSummarizer
+from ..utils import get_stop_words
+
+
+class KLSummarizer(AbstractSummarizer):
+    """
+    Method that greedily adds sentences to a summary so long as it decreases the 
+    KL Divergence.
+    Source: http://www.aclweb.org/anthology/N09-1041
+    """
+
+    def __call__(self, document, sentences_count):
+        ratings = self._get_ratings(document)
+        return self._get_best_sentences(document.sentences, sentences_count, ratings)
+
+    def _get_ratings(self, document):
+        sentences = document.sentences
+
+        ratings = self._compute_ratings(sentences)
+        return ratings
+
+    def _get_all_words_in_doc(self, sentences):
+        return [w for s in sentences for w in s.words]
+
+    def _get_content_words_in_sentence(self, sentence):
+        normalized_words = self._normalize_words(sentence.words)   
+        normalized_content_words = self._filter_out_stop_words(normalized_words)
+        return normalized_content_words
+
+    def _normalize_words(self, words):
+        return [self.normalize_word(w) for w in words]
+
+    def _filter_out_stop_words(self, words):
+        return [w for w in words if w not in self.stop_words]
+
+    def _compute_word_freq(self, list_of_words):
+        word_freq = {}
+        for w in list_of_words:
+            word_freq[w] = word_freq.get(w, 0) + 1
+        return word_freq
+
+    def _get_all_content_words_in_doc(self, sentences):
+        all_words = self._get_all_words_in_doc(sentences)
+        content_words = self._filter_out_stop_words(all_words)
+        normalized_content_words = self._normalize_words(content_words)
+        return normalized_content_words
+        
+    def _compute_tf(self, sentences):
+        '''
+        Computes the normalized term frequency as explained in http://www.tfidf.com/
+        '''
+        content_words = self._get_all_content_words_in_doc(sentences)
+        content_words_count = len(content_words)
+        content_words_freq = self._compute_word_freq(content_words)
+        content_word_tf = dict((k, v / content_words_count) for (k, v) in content_words_freq.items())
+        return content_word_tf
+
+    def _joint_freq(self, word_list_1, word_list_2):
+        # combined length of the word lists
+        total_len = len(word_list_1) + len(word_list_2)
+
+        # word frequencies within each list
+        wc1 = self._compute_word_freq(word_list_1)
+        wc2 = self._compute_word_freq(word_list_2)
+
+        # inputs the counts from the first list
+        joint = wc1.copy()
+
+        # adds in the counts of the second list
+        for k in wc2:
+            if k in joint: 
+                joint[k] += wc2[k]
+            else: joint[k] = wc2[k]
+
+        # divides total counts by the combined length
+        for k in joint:
+            joint[k] /= float(total_len)
+
+        return joint
+
+    def _kl_divergence(self, summary_freq, doc_freq):
+        '''
+        Note: Could import scipy.stats and use scipy.stats.entropy(doc_freq, summary_freq)
+        but this gives equivalent value without the import
+        '''
+        sum_val = 0
+        for w in summary_freq:
+            sum_val += doc_freq[w] * math.log(doc_freq[w] / summary_freq[w])
+        return sum_val
+
+    def _find_index_of_best_sentence(self, kls):
+        '''
+        the best sentence is the one with the smallest kl_divergence
+        '''
+        indexToRemove = kls.index(min(kls))
+        return indexToRemove
+
+    def _compute_ratings(self, sentences):
+        word_freq = self._compute_tf(sentences)
+        ratings = {}
+        summary = []
+
+        # make it a list so that it can be modified
+        sentences_list = list(sentences)
+
+        # get all content words once for efficiency
+        sentences_as_words = [self._get_content_words_in_sentence(s) for s in sentences]
+        
+        # Removes one sentence per iteration by adding to summary
+        while len(sentences_list) > 0:
+            # will store all the kls values for this pass
+            kls = []
+            
+            # converts summary to word list
+            summary_as_word_list = self._get_all_words_in_doc(summary)
+            
+            for s in sentences_as_words:
+                # calculates the joint frequency through combining the word lists
+                joint_freq = self._joint_freq(s, summary_as_word_list)
+
+                # adds the calculated kl divergence to the list in index = sentence used
+                kls.append(self._kl_divergence(joint_freq, word_freq))
+
+            # to consider and then add it into the summary
+            indexToRemove = self._find_index_of_best_sentence(kls)
+            best_sentence = sentences_list.pop(indexToRemove)
+            del sentences_as_words[indexToRemove]
+            summary.append(best_sentence)
+
+            # value is the iteration in which it was removed multiplied by -1 so that the first sentences removed (the most important) have highest values
+            ratings[best_sentence] =  -1 * len(ratings)
+
+        return ratings
+

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,6 +27,7 @@ class TestMain(unittest.TestCase):
         'luhn': False,
         'text-rank': False,
         'sum-basic': False,
+        'kl': False,
     }
 
     def test_ok_args(self):

--- a/tests/test_summarizers/test_kl.py
+++ b/tests/test_summarizers/test_kl.py
@@ -1,0 +1,103 @@
+# -*- coding: utf8 -*-
+
+from __future__ import absolute_import
+from __future__ import division, print_function, unicode_literals
+
+import unittest
+
+from sumy.models.dom._sentence import Sentence
+from sumy.summarizers.kl import KLSummarizer
+from sumy._compat import to_unicode
+from ..utils import build_document, build_document_from_string
+from sumy.nlp.tokenizers import Tokenizer
+
+
+class TestKL(unittest.TestCase):
+    EMPTY_STOP_WORDS = []
+    COMMON_STOP_WORDS = ["the", "and", "i"]
+
+    def _build_summarizer(self, stop_words):
+        summarizer = KLSummarizer()
+        summarizer.stop_words = stop_words
+        return summarizer
+
+    def test_empty_document(self):
+        document = build_document()
+        summarizer = self._build_summarizer(self.EMPTY_STOP_WORDS)
+
+        returned = summarizer(document, 10)
+        self.assertEqual(len(returned), 0)
+
+    def test_single_sentence(self):
+
+        s = Sentence("I am one slightly longer sentence.", Tokenizer("english"))
+        document = build_document([s])
+        summarizer = self._build_summarizer(self.EMPTY_STOP_WORDS)
+
+        returned = summarizer(document, 10)
+        self.assertEqual(len(returned), 1)
+
+    def test_compute_word_freq(self):
+        
+        summarizer = self._build_summarizer(self.EMPTY_STOP_WORDS)
+        
+        words = ["one", "two", "three", "four"]
+        freq = summarizer._compute_word_freq(words)
+        self.assertEqual(freq.get("one", 0), 1)
+        self.assertEqual(freq.get("two", 0), 1)
+        self.assertEqual(freq.get("three", 0), 1)
+        self.assertEqual(freq.get("four", 0), 1)
+        
+        words = ["one", "one", "two", "two"]
+        freq = summarizer._compute_word_freq(words)
+        self.assertEqual(freq.get("one", 0), 2)
+        self.assertEqual(freq.get("two", 0), 2)
+        self.assertEqual(freq.get("three", 0), 0)
+
+    def test_joint_freq(self):
+        summarizer = self._build_summarizer(self.EMPTY_STOP_WORDS)
+        w1 = ["one", "two", "three", "four"]
+        w2 = ["one", "two", "three", "four"]
+        freq = summarizer._joint_freq(w1, w2)
+        self.assertEqual(freq["one"], 1.0/4)
+        self.assertEqual(freq["two"], 1.0/4)
+        self.assertEqual(freq["three"], 1.0/4)
+        self.assertEqual(freq["four"], 1.0/4)
+
+        w1 = ["one", "two", "three", "four"]
+        w2 = ["one", "one", "three", "five"]
+        freq = summarizer._joint_freq(w1, w2)
+        self.assertEqual(freq["one"], 3.0/8)
+        self.assertEqual(freq["two"], 1.0/8)
+        self.assertEqual(freq["three"], 1.0/4)
+        self.assertEqual(freq["four"], 1.0/8)
+        self.assertEqual(freq["five"], 1.0/8)
+
+    def test_kl_divergence(self):
+        summarizer = self._build_summarizer(self.EMPTY_STOP_WORDS)
+        EPS = 0.00001
+
+
+        w1 = {"one":.35, "two":.5, "three":.15}
+        w2 = {"one":1.0/3.0, "two":1.0/3.0, "three":1.0/3.0}
+
+        w1_ = [.35, .5, .15]
+        w2_ = [1.0/3.0, 1.0/3.0, 1.0/3.0]
+
+        # This value comes from scipy.stats.entropy(w2_, w1_)
+        # Note: the order of params is different
+        kl_correct = 0.11475080798005841
+        self.assertTrue(abs(summarizer._kl_divergence(w1, w2) - kl_correct < EPS))
+
+        w1 = {"one":.1, "two":.2, "three":.7}
+        w2 = {"one":.2, "two":.4, "three":.4}
+
+        w1_ = [.1, .2, .7]
+        w2_ = [.2, .4, .4]
+        
+        # This value comes from scipy.stats.entropy(w2_, w1_)
+        # Note: the order of params is different
+        kl_correct = 0.1920419931617981
+        self.assertTrue(abs(summarizer._kl_divergence(w1, w2) - kl_correct) < EPS)
+
+


### PR DESCRIPTION
This pull request adds the KL-Sum algorithm for summarizing. KL-Sum is a method that greedily adds sentences to a summary so long as it decreases the KL Divergence between the word frequencies of the document and the word frequencies of the summary. KL-Sum is often used as a strong baseline algorithm that more novel methods are compared to. Source: http://www.aclweb.org/anthology/N09-1041

