### PR TITLE
Fixes infinite loop when parsing from a url that has a 301 redirect

### DIFF
--- a/sumy/parsers/html.py
+++ b/sumy/parsers/html.py
@@ -32,7 +32,7 @@ class HtmlParser(DocumentParser):
 
     @classmethod
     def from_url(cls, url, tokenizer):
-        response = urllib.urlopen(url)
+        response = urllib.build_opener(urllib.HTTPCookieProcessor).open(url)
         data = response.read()
         response.close()
 


### PR DESCRIPTION
Python 3.4 and 2.7 tests pass.