### PR TITLE
Use requests library for fetching URLs, fixes #37

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "docopt>=0.6.1,<0.7",
         "breadability>=0.1.20",
         "nltk>=3.0.2",
+        "requests>=2.7.0",
     ],
     tests_require=[
         "pytest",

--- a/sumy/_compat.py
+++ b/sumy/_compat.py
@@ -19,12 +19,6 @@ string_types = (bytes, unicode,)
 
 
 try:
-    import urllib2 as urllib
-except ImportError:
-    from urllib import request as urllib
-
-
-try:
     from itertools import ifilterfalse as ffilter
 except ImportError:
     from itertools import filterfalse as ffilter

--- a/sumy/parsers/html.py
+++ b/sumy/parsers/html.py
@@ -4,8 +4,7 @@ from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
 
 from breadability.readable import Article
-from .._compat import urllib
-from ..utils import cached_property
+from ..utils import cached_property, fetch_url
 from ..models.dom import Sentence, Paragraph, ObjectDocumentModel
 from .parser import DocumentParser
 
@@ -32,10 +31,7 @@ class HtmlParser(DocumentParser):
 
     @classmethod
     def from_url(cls, url, tokenizer):
-        response = urllib.urlopen(url)
-        data = response.read()
-        response.close()
-
+        data = fetch_url(url)
         return cls(data, tokenizer, url)
 
     def __init__(self, html_content, tokenizer, url=None):

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -4,10 +4,24 @@ from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
 
 import sys
+import requests
 
 from functools import wraps
+from contextlib import closing
 from os.path import dirname, abspath, join, exists
+from . import __version__
 from ._compat import to_string, to_unicode, string_types
+
+_HTTP_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36 OPR/31.0.1889.174",
+    # "User-Agent": "Sumy (Automatic text summarizer) Version/%s" % __version__,
+}
+
+
+def fetch_url(url):
+    with closing(requests.get(url, headers=_HTTP_HEADERS)) as response:
+        response.raise_for_status()
+        return response.content
 
 
 def cached_property(getter):
@@ -55,7 +69,7 @@ class ItemsCount(object):
             if self._value.endswith("%"):
                 total_count = len(sequence)
                 percentage = int(self._value[:-1])
-                # at least one sentence should be choosen
+                # at least one sentence should be chosen
                 count = max(1, total_count*percentage // 100)
                 return sequence[:count]
             else:


### PR DESCRIPTION
Uses requests library for fetching documents from URLs and also *User-Agent* header is set to mimic browser to avoid filtering from some servers.