### PR TITLE
Explicit setup instructions for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ if __name__ == "__main__":
 
 ## Tests
 
+Setup:
+```sh
+$ pip install pytest pytest-cov
+```
+
 Run tests via
 
 ```sh


### PR DESCRIPTION
It isn't obvious from the current README that `pytest-cov` module has to be installed. If run just `pytest` without the module, nasty error message occurs. 

```sh
py.test: error: unrecognized arguments: --cov=sumy --cov-report=term-missing --no-cov-on-fail
```