### PR TITLE
fix package included resources reading to standard pkgutil mechanism

### DIFF
--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -5,6 +5,7 @@ from __future__ import division, print_function, unicode_literals
 
 import sys
 import requests
+import pkgutil
 
 from functools import wraps
 from contextlib import closing
@@ -49,15 +50,20 @@ def expand_resource_path(path):
 
 
 def get_stop_words(language):
-    path = expand_resource_path("stopwords/%s.txt" % language)
-    if not exists(path):
+    try:
+        stopwords_data = pkgutil.get_data("sumy", "data/stopwords/%s.txt" % language)
+    except IOError as e:
         raise LookupError("Stop-words are not available for language %s." % language)
-    return read_stop_words(path)
+    return parse_stop_words(stopwords_data)
 
 
 def read_stop_words(filename):
     with open(filename, "rb") as open_file:
-        return frozenset(to_unicode(w.rstrip()) for w in open_file.readlines())
+        return parse_stop_words(open_file.read())
+
+
+def parse_stop_words(data):
+    return frozenset(w.rstrip() for w in to_unicode(data).split("\n") if w)
 
 
 class ItemsCount(object):

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -63,7 +63,7 @@ def read_stop_words(filename):
 
 
 def parse_stop_words(data):
-    return frozenset(w.rstrip() for w in to_unicode(data).split("\n") if w)
+    return frozenset(w.rstrip() for w in to_unicode(data).splitlines() if w)
 
 
 class ItemsCount(object):


### PR DESCRIPTION
Old logic doesn't work when I use .egg files to distribute modules because of os.path can't lookup inside .egg archive, but pkgutil can do it!