### PR TITLE
Fixing setup.py to read from README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import sys
 VERSION_SUFFIX = "%d.%d" % sys.version_info[:2]
 
 
-with open("README.rst") as readme:
+with open("README.md") as readme:
     long_description = readme.read()
 
 


### PR DESCRIPTION
It was initially reading from `README.rst`. There was only a `README.md` in this branch.