### PR TITLE
changed readme extension to match current readme file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import sys
 VERSION_SUFFIX = "%d.%d" % sys.version_info[:2]
 
 
-with open("README.rst") as readme:
+with open("README.md") as readme:
     long_description = readme.read()
 
 


### PR DESCRIPTION
This is a trivial fix for setup installation errors. The readme file specified in setup.py is 

`README.rst` but the project comes with a markdown version. 
