### PR TITLE
Add --text command line option

### DIFF
--- a/sumy/__main__.py
+++ b/sumy/__main__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 """
 Sumy - automatic text summarizer.
@@ -7,6 +7,7 @@ Usage:
     sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>]
     sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --url=<url>
     sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --file=<file_path>
+    sumy (luhn | edmundson | lsa | text-rank | lex-rank | sum-basic | kl) [--length=<length>] [--language=<lang>] [--stopwords=<file_path>] [--format=<format>] --text=<text>
     sumy --version
     sumy --help
 
@@ -19,6 +20,7 @@ Options:
     --format=<format>        Format of input document. Possible values: html, plaintext
     --url=<url>              URL address of the web page to summarize.
     --file=<file_path>       Path to the text file to summarize.
+    --text=<text>            Raw text to summarize
     --version                Displays current application version.
     --help                   Displays this text.
 
@@ -89,6 +91,9 @@ def handle_arguments(args, default_input_stream=sys.stdin):
         parser = PARSERS[document_format or "plaintext"]
         with open(args["--file"], "rb") as file:
             document_content = file.read()
+    elif args["--text"] is not None:
+        parser = PARSERS[document_format or "plaintext"]
+        document_content = args["--text"]
     else:
         parser = PARSERS[document_format or "plaintext"]
         document_content = default_input_stream.read()
@@ -104,8 +109,10 @@ def handle_arguments(args, default_input_stream=sys.stdin):
     parser = parser(document_content, Tokenizer(language))
     stemmer = Stemmer(language)
 
-    summarizer_class = next(cls for name, cls in AVAILABLE_METHODS.items() if args[name])
-    summarizer = build_summarizer(summarizer_class, stop_words, stemmer, parser)
+    summarizer_class = next(
+        cls for name, cls in AVAILABLE_METHODS.items() if args[name])
+    summarizer = build_summarizer(
+        summarizer_class, stop_words, stemmer, parser)
 
     return summarizer, parser, items_count
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
@@ -20,6 +20,7 @@ class TestMain(unittest.TestCase):
         '--length': '20%',
         '--stopwords': None,
         '--url': None,
+        '--text': None,
         '--version': False,
         'edmundson': False,
         'lex-rank': False,
@@ -31,25 +32,35 @@ class TestMain(unittest.TestCase):
     }
 
     def test_ok_args(self):
-        docopt(to_string(main_doc), 'luhn --url=URL --format=FORMAT'.split(), version=__version__)
+        docopt(to_string(main_doc),
+               'luhn --url=URL --format=FORMAT'.split(), version=__version__)
 
     def test_args_none(self):
-        self.assertRaises(DocoptExit, docopt, to_string(main_doc), None, version=__version__)
+        self.assertRaises(DocoptExit, docopt, to_string(
+            main_doc), None, version=__version__)
 
     def test_args_just_command(self):
         args = docopt(to_string(main_doc), ['lsa'], version=__version__)
         self.assertEqual(self.DEFAULT_ARGS, args)
 
     def test_args_two_commands(self):
-        self.assertRaises(DocoptExit, docopt, to_string(main_doc), 'lsa luhn'.split(), version=__version__)
+        self.assertRaises(DocoptExit, docopt, to_string(
+            main_doc), 'lsa luhn'.split(), version=__version__)
 
     def test_args_url_and_file(self):
-        self.assertRaises(DocoptExit, docopt, to_string(main_doc), 'lsa --url=URL --file=FILE'.split(), version=__version__)
+        self.assertRaises(DocoptExit, docopt, to_string(
+            main_doc), 'lsa --url=URL --file=FILE'.split(), version=__version__)
+
+    def test_args_url_and_text(self):
+        self.assertRaises(DocoptExit, docopt, to_string(
+            main_doc), 'lsa --url=URL --text=TEXT'.split(), version=__version__)
 
     def test_handle_default_arguments(self):
-        handle_arguments(self.DEFAULT_ARGS, default_input_stream=StringIO("Whatever."))
+        handle_arguments(self.DEFAULT_ARGS,
+                         default_input_stream=StringIO("Whatever."))
 
     def test_handle_wrong_format(self):
         wrong_args = self.DEFAULT_ARGS.copy()
         wrong_args.update({'--url': 'URL', '--format': 'text'})
-        self.assertRaises(ValueError, handle_arguments, wrong_args, default_input_stream=StringIO("Whatever."))
+        self.assertRaises(ValueError, handle_arguments, wrong_args,
+                          default_input_stream=StringIO("Whatever."))


### PR DESCRIPTION
This is adds an additional --text command line issue or issue https://github.com/miso-belica/sumy/issues/66 . An alias to piping.

I also applied pep8 to `__main__.py` and `test_main.py`. 

The weird thing I noticed is that there is an editor specific line... `-# -*- coding: utf8 -*-` which seems like Emacs. IDK. But I think that should be removed if only editors are using that.
