### PR TITLE
fix _get_word_ngrams()

### DIFF
--- a/sumy/evaluation/rouge.py
+++ b/sumy/evaluation/rouge.py
@@ -28,8 +28,12 @@ def _get_word_ngrams(n, sentences):
 	assert (len(sentences) > 0)
 	assert (n > 0)
 
-	words = _split_into_words(sentences)
-	return _get_ngrams(n, words)
+	words = set()
+	for sentence in sentences:
+		words.update(_get_ngrams(n,_split_into_words([sentence])))
+		
+	return words
+
 
 
 def _get_index_of_lcs(x, y):

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -216,19 +216,28 @@ class TestRougeEvaluation(unittest.TestCase):
             Tokenizer("english")).document.sentences
         self.assertEqual(["One", "two", "two", "Two", "Three"], 
             _split_into_words(sentences1))
-        
         sentences2 = PlaintextParser.from_string("two two. Two. Three.", 
             Tokenizer("english")).document.sentences
         self.assertEqual(["two", "two", "Two", "Three"], 
             _split_into_words(sentences2))
 
+
     def test_get_word_ngrams(self):
-        sentences = PlaintextParser.from_string("This is a test.", 
-            Tokenizer("english")).document.sentences
+        sentences = PlaintextParser.from_string("This is a test.",
+                                                Tokenizer("english")).document.sentences
         correct_ngrams = [("This", "is"), ("is", "a"), ("a", "test")]
         found_ngrams = _get_word_ngrams(2, sentences)
         for ngram in correct_ngrams:
-            self.assertTrue(ngram in found_ngrams)      
+            self.assertTrue(ngram in found_ngrams)
+
+        # test with long text
+        sentences = PlaintextParser.from_string("This is a pencil.\nThis is a eraser.\nThis is a book.",
+                                                Tokenizer("english")).document.sentences
+        correct_ngrams = [("This", "is"), ("is", "a"), ("a", "pencil"), ("a", "eraser"), ("a", "book")]
+        found_ngrams = _get_word_ngrams(2, sentences)
+        for ngram in correct_ngrams:
+            self.assertTrue(ngram in found_ngrams)
+
 
     def test_len_lcs(self):
         self.assertEqual(_len_lcs("1234", "1224533324"), 4)


### PR DESCRIPTION
Hi,
I get a wrong tuple, ('test','This'), in the results, when inputting two sentences, 'This is a test' and 'This is a contest', to the _get_word_ngrams(2, sentences). The expected results are ('This','is'), ('is','a'), ('a','test'), ('a','contest').

![default](https://cloud.githubusercontent.com/assets/4332648/23337369/035c8308-fc26-11e6-88c1-e180dc1a3d17.PNG)

The image clearly shows debug results when running test_get_word_ngrams() using PyCharm.

The reason to the mistake results is that _get_word_ngrams() concatenates all words of sentences and then calls _get_ngrams(n, words).

I correct _get_word_ngrams() code that the sentences will not be concatenated.
