### PR TITLE
Fix TextRank algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,15 @@ framework for text summaries. Implemented summarization methods:
 -   **LexRank** - Unsupervised approach inspired by algorithms PageRank
     and HITS,
     [reference](http://tangra.si.umich.edu/~radev/lexrank/lexrank.pdf)
--   **TextRank** - some sort of combination of a few resources that I
-    found on the internet. I really don't remember the sources. Probably
-    [Wikipedia](https://en.wikipedia.org/wiki/Automatic_summarization#Unsupervised_approaches:_TextRank_and_LexRank)
-    and some papers in 1st page of Google :)
+-   **TextRank** - Unsupervised approach, also using PageRank algorithm,
+    [reference](https://web.eecs.umich.edu/~mihalcea/papers/mihalcea.emnlp04.pdf)
 -   **SumBasic** - Method that is often used as a baseline in
     the literature. Source: [Read about
     SumBasic](http://www.cis.upenn.edu/~nenkova/papers/ipm.pdf)
 -   **KL-Sum** - Method that greedily adds sentences to a summary so
     long as it decreases the KL Divergence. Source: [Read about
     KL-Sum](http://www.aclweb.org/anthology/N09-1041)
+-   **Reduction** - Graph-based summarization, taken from https://github.com/adamfabish/Reduction
 
 Here are some other summarizers:
 
@@ -140,15 +139,16 @@ if __name__ == "__main__":
         print(sentence)
 ```
 
-## Tests
+## Contributing
 
-Setup:
+Make sure you have Python 2.7 or 3.3+ installed. Then, install all the required dependencies:
+
 ```sh
-$ pip install pytest pytest-cov
+$ pip install -r requirements.txt
 ```
 
-Run tests via
+You can run the tests via
 
 ```sh
-$ py.test-2.7 && py.test-3.3 && py.test-3.4 && py.test-3.5
+$ pytest
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ framework for text summaries. Implemented summarization methods:
 -   **KL-Sum** - Method that greedily adds sentences to a summary so
     long as it decreases the KL Divergence. Source: [Read about
     KL-Sum](http://www.aclweb.org/anthology/N09-1041)
--   **Reduction** - Graph-based summarization, taken from https://github.com/adamfabish/Reduction
+-   **Reduction** - Graph-based summarization, where a sentence salience is
+    computed as the sum of the weights of its edges to other sentences. The
+    weight of an edge between two sentences is computed in the same manner
+    as TextRank.
 
 Here are some other summarizers:
 
@@ -144,7 +147,7 @@ if __name__ == "__main__":
 Make sure you have Python 2.7 or 3.3+ installed. Then, install all the required dependencies:
 
 ```sh
-$ pip install -r requirements.txt
+$ pip install -U pytest pytest-cov -e .
 ```
 
 You can run the tests via

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-breadability==0.1.20
-docopt==0.6.1
-jieba==0.39
-nltk==3.2.5
-numpy==1.14.0
-pytest==3.3.2
-pytest-cov==2.5.1
-requests==2.7.0
-tinysegmenter==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+breadability==0.1.20
+docopt==0.6.1
+jieba==0.39
+nltk==3.2.5
+numpy==1.14.0
+pytest==3.3.2
+pytest-cov==2.5.1
+requests==2.7.0
+tinysegmenter==0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ tag = false
 
 [bumpversion:file:sumy/__init__.py]
 
-[pytest]
+[tool:pytest]
 addopts = --quiet --tb=short --color=yes --cov=sumy --cov-report=term-missing --no-cov-on-fail
 
 [pep8]

--- a/sumy/summarizers/reduction.py
+++ b/sumy/summarizers/reduction.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division, print_function, unicode_literals
+
+import math
+
+from itertools import combinations
+from collections import defaultdict
+from ._summarizer import AbstractSummarizer
+
+
+class ReductionSummarizer(AbstractSummarizer):
+    """Source: https://github.com/adamfabish/Reduction"""
+
+    _stop_words = frozenset()
+
+    @property
+    def stop_words(self):
+        return self._stop_words
+
+    @stop_words.setter
+    def stop_words(self, words):
+        self._stop_words = frozenset(map(self.normalize_word, words))
+
+    def __call__(self, document, sentences_count):
+        ratings = self.rate_sentences(document)
+        return self._get_best_sentences(document.sentences, sentences_count, ratings)
+
+    def rate_sentences(self, document):
+        sentences_words = [(s, self._to_words_set(s)) for s in document.sentences]
+        ratings = defaultdict(float)
+
+        for (sentence1, words1), (sentence2, words2) in combinations(sentences_words, 2):
+            rank = self._rate_sentences_edge(words1, words2)
+            ratings[sentence1] += rank
+            ratings[sentence2] += rank
+
+        return ratings
+
+    def _to_words_set(self, sentence):
+        words = map(self.normalize_word, sentence.words)
+        return [self.stem_word(w) for w in words if w not in self._stop_words]
+
+    def _rate_sentences_edge(self, words1, words2):
+        rank = 0
+        for w1 in words1:
+            for w2 in words2:
+                rank += int(w1 == w2)
+
+        if rank == 0:
+            return 0.0
+
+        assert len(words1) > 0 and len(words2) > 0
+        norm = math.log(len(words1)) + math.log(len(words2))
+        return 0.0 if norm == 0.0 else rank / norm

--- a/tests/test_summarizers/test_reduction.py
+++ b/tests/test_summarizers/test_reduction.py
@@ -4,38 +4,24 @@ from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
 
 import unittest
-import pytest
 
-import sumy.summarizers.text_rank as text_rank_module
-from sumy.summarizers.text_rank import TextRankSummarizer
+from sumy.summarizers.reduction import ReductionSummarizer
 from sumy.nlp.stemmers import Stemmer
 from sumy._compat import to_unicode
 from ..utils import build_document
 
 
-def test_numpy_not_installed():
-    summarizer = TextRankSummarizer()
-
-    numpy = text_rank_module.numpy
-    text_rank_module.numpy = None
-
-    with pytest.raises(ValueError):
-        summarizer(build_document(), 10)
-
-    text_rank_module.numpy = numpy
-
-
 class TestTextRank(unittest.TestCase):
     def test_empty_document(self):
         document = build_document()
-        summarizer = TextRankSummarizer(Stemmer("english"))
+        summarizer = ReductionSummarizer(Stemmer("english"))
 
         returned = summarizer(document, 10)
         self.assertEqual(len(returned), 0)
 
     def test_single_sentence(self):
         document = build_document(("I am one sentence",))
-        summarizer = TextRankSummarizer()
+        summarizer = ReductionSummarizer()
         summarizer.stop_words = ("I", "am",)
 
         returned = summarizer(document, 10)
@@ -43,7 +29,7 @@ class TestTextRank(unittest.TestCase):
 
     def test_two_sentences(self):
         document = build_document(("I am that 1. sentence", "And I am 2. winning prize"))
-        summarizer = TextRankSummarizer()
+        summarizer = ReductionSummarizer()
         summarizer.stop_words = ("I", "am", "and", "that",)
 
         returned = summarizer(document, 10)
@@ -52,7 +38,7 @@ class TestTextRank(unittest.TestCase):
         self.assertEqual(to_unicode(returned[1]), "And I am 2. winning prize")
 
     def test_stop_words_correctly_removed(self):
-        summarizer = TextRankSummarizer()
+        summarizer = ReductionSummarizer()
         summarizer.stop_words = ["stop", "Halt", "SHUT", "HmMm"]
 
         document = build_document(
@@ -79,15 +65,29 @@ class TestTextRank(unittest.TestCase):
         returned = summarizer._to_words_set(sentences[5])
         self.assertEqual(expected, returned)
 
+    def test_three_sentences_but_second_winner(self):
+        document = build_document([
+            "I am that 1. sentence",
+            "And I am 2. sentence - winning sentence",
+            "And I am 3. sentence - winner is my 2nd name",
+        ])
+        summarizer = ReductionSummarizer()
+        summarizer.stop_words = ["I", "am", "and", "that"]
+
+        returned = summarizer(document, 1)
+        self.assertEqual(len(returned), 1)
+        self.assertEqual(to_unicode(returned[0]), "And I am 2. sentence - winning sentence")
+
     def test_sentences_rating(self):
         document = build_document([
             "a c e g",
             "a b c d e f g",
             "b d f",
         ])
-        summarizer = TextRankSummarizer()
+        summarizer = ReductionSummarizer()
         summarizer.stop_words = ["I", "am", "and", "that"]
 
         ratings = summarizer.rate_sentences(document)
         self.assertEqual(len(ratings), 3)
-        self.assertAlmostEqual(sum(ratings.values()), 1)
+        self.assertTrue(ratings[document.sentences[1]] > ratings[document.sentences[0]])
+        self.assertTrue(ratings[document.sentences[0]] > ratings[document.sentences[2]])

--- a/tests/test_summarizers/test_reduction.py
+++ b/tests/test_summarizers/test_reduction.py
@@ -3,91 +3,93 @@
 from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
 
-import unittest
-
 from sumy.summarizers.reduction import ReductionSummarizer
 from sumy.nlp.stemmers import Stemmer
 from sumy._compat import to_unicode
 from ..utils import build_document
 
 
-class TestTextRank(unittest.TestCase):
-    def test_empty_document(self):
-        document = build_document()
-        summarizer = ReductionSummarizer(Stemmer("english"))
+def test_empty_document():
+    document = build_document()
+    summarizer = ReductionSummarizer(Stemmer("english"))
 
-        returned = summarizer(document, 10)
-        self.assertEqual(len(returned), 0)
+    returned = summarizer(document, 10)
+    assert len(returned) == 0
 
-    def test_single_sentence(self):
-        document = build_document(("I am one sentence",))
-        summarizer = ReductionSummarizer()
-        summarizer.stop_words = ("I", "am",)
 
-        returned = summarizer(document, 10)
-        self.assertEqual(len(returned), 1)
+def test_single_sentence():
+    document = build_document(("I am one sentence",))
+    summarizer = ReductionSummarizer()
+    summarizer.stop_words = ("I", "am",)
 
-    def test_two_sentences(self):
-        document = build_document(("I am that 1. sentence", "And I am 2. winning prize"))
-        summarizer = ReductionSummarizer()
-        summarizer.stop_words = ("I", "am", "and", "that",)
+    returned = summarizer(document, 10)
+    assert len(returned) == 1
 
-        returned = summarizer(document, 10)
-        self.assertEqual(len(returned), 2)
-        self.assertEqual(to_unicode(returned[0]), "I am that 1. sentence")
-        self.assertEqual(to_unicode(returned[1]), "And I am 2. winning prize")
 
-    def test_stop_words_correctly_removed(self):
-        summarizer = ReductionSummarizer()
-        summarizer.stop_words = ["stop", "Halt", "SHUT", "HmMm"]
+def test_two_sentences():
+    document = build_document(("I am that 1. sentence", "And I am 2. winning prize"))
+    summarizer = ReductionSummarizer()
+    summarizer.stop_words = ("I", "am", "and", "that",)
 
-        document = build_document(
-            ("stop halt shut hmmm", "Stop Halt Shut Hmmm",),
-            ("StOp HaLt ShUt HmMm", "STOP HALT SHUT HMMM",),
-            ("Some relevant sentence", "Some moRe releVant sentEnce",),
-        )
-        sentences = document.sentences
+    returned = summarizer(document, 10)
+    assert len(returned) == 2
+    assert to_unicode(returned[0]) == "I am that 1. sentence"
+    assert to_unicode(returned[1]) == "And I am 2. winning prize"
 
-        expected = []
-        returned = summarizer._to_words_set(sentences[0])
-        self.assertEqual(expected, returned)
-        returned = summarizer._to_words_set(sentences[1])
-        self.assertEqual(expected, returned)
-        returned = summarizer._to_words_set(sentences[2])
-        self.assertEqual(expected, returned)
-        returned = summarizer._to_words_set(sentences[3])
-        self.assertEqual(expected, returned)
 
-        expected = ["some", "relevant", "sentence"]
-        returned = summarizer._to_words_set(sentences[4])
-        self.assertEqual(expected, returned)
-        expected = ["some", "more", "relevant", "sentence"]
-        returned = summarizer._to_words_set(sentences[5])
-        self.assertEqual(expected, returned)
+def test_stop_words_correctly_removed():
+    summarizer = ReductionSummarizer()
+    summarizer.stop_words = ["stop", "Halt", "SHUT", "HmMm"]
 
-    def test_three_sentences_but_second_winner(self):
-        document = build_document([
-            "I am that 1. sentence",
-            "And I am 2. sentence - winning sentence",
-            "And I am 3. sentence - winner is my 2nd name",
-        ])
-        summarizer = ReductionSummarizer()
-        summarizer.stop_words = ["I", "am", "and", "that"]
+    document = build_document(
+        ("stop halt shut hmmm", "Stop Halt Shut Hmmm",),
+        ("StOp HaLt ShUt HmMm", "STOP HALT SHUT HMMM",),
+        ("Some relevant sentence", "Some moRe releVant sentEnce",),
+    )
+    sentences = document.sentences
 
-        returned = summarizer(document, 1)
-        self.assertEqual(len(returned), 1)
-        self.assertEqual(to_unicode(returned[0]), "And I am 2. sentence - winning sentence")
+    expected = []
+    returned = summarizer._to_words_set(sentences[0])
+    assert expected == returned
+    returned = summarizer._to_words_set(sentences[1])
+    assert expected == returned
+    returned = summarizer._to_words_set(sentences[2])
+    assert expected == returned
+    returned = summarizer._to_words_set(sentences[3])
+    assert expected == returned
 
-    def test_sentences_rating(self):
-        document = build_document([
-            "a c e g",
-            "a b c d e f g",
-            "b d f",
-        ])
-        summarizer = ReductionSummarizer()
-        summarizer.stop_words = ["I", "am", "and", "that"]
+    expected = ["some", "relevant", "sentence"]
+    returned = summarizer._to_words_set(sentences[4])
+    assert expected == returned
+    expected = ["some", "more", "relevant", "sentence"]
+    returned = summarizer._to_words_set(sentences[5])
+    assert expected == returned
 
-        ratings = summarizer.rate_sentences(document)
-        self.assertEqual(len(ratings), 3)
-        self.assertTrue(ratings[document.sentences[1]] > ratings[document.sentences[0]])
-        self.assertTrue(ratings[document.sentences[0]] > ratings[document.sentences[2]])
+
+def test_three_sentences_but_second_winner():
+    document = build_document([
+        "I am that 1. sentence",
+        "And I am 2. sentence - winning sentence",
+        "And I am 3. sentence - winner is my 2nd name",
+    ])
+    summarizer = ReductionSummarizer()
+    summarizer.stop_words = ["I", "am", "and", "that"]
+
+    returned = summarizer(document, 1)
+    assert len(returned) == 1
+    assert to_unicode(returned[0]) == "And I am 2. sentence - winning sentence"
+
+
+def test_sentences_rating():
+    document = build_document([
+        "a c e g",
+        "a b c d e f g",
+        "b d f",
+    ])
+    summarizer = ReductionSummarizer()
+    summarizer.stop_words = ["I", "am", "and", "that"]
+
+    ratings = summarizer.rate_sentences(document)
+    assert len(ratings) == 3
+    assert ratings[document.sentences[1]] > ratings[document.sentences[0]]
+    assert ratings[document.sentences[0]] > ratings[document.sentences[2]]

--- a/tests/test_summarizers/test_text_rank.py
+++ b/tests/test_summarizers/test_text_rank.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 from __future__ import division, print_function, unicode_literals
 
-import unittest
 import pytest
 
 import sumy.summarizers.text_rank as text_rank_module
@@ -25,69 +24,72 @@ def test_numpy_not_installed():
     text_rank_module.numpy = numpy
 
 
-class TestTextRank(unittest.TestCase):
-    def test_empty_document(self):
-        document = build_document()
-        summarizer = TextRankSummarizer(Stemmer("english"))
+def test_empty_document():
+    document = build_document()
+    summarizer = TextRankSummarizer(Stemmer("english"))
 
-        returned = summarizer(document, 10)
-        self.assertEqual(len(returned), 0)
+    returned = summarizer(document, 10)
+    assert len(returned) == 0
 
-    def test_single_sentence(self):
-        document = build_document(("I am one sentence",))
-        summarizer = TextRankSummarizer()
-        summarizer.stop_words = ("I", "am",)
 
-        returned = summarizer(document, 10)
-        self.assertEqual(len(returned), 1)
+def test_single_sentence():
+    document = build_document(("I am one sentence",))
+    summarizer = TextRankSummarizer()
+    summarizer.stop_words = ("I", "am",)
 
-    def test_two_sentences(self):
-        document = build_document(("I am that 1. sentence", "And I am 2. winning prize"))
-        summarizer = TextRankSummarizer()
-        summarizer.stop_words = ("I", "am", "and", "that",)
+    returned = summarizer(document, 10)
+    assert len(returned) == 1
 
-        returned = summarizer(document, 10)
-        self.assertEqual(len(returned), 2)
-        self.assertEqual(to_unicode(returned[0]), "I am that 1. sentence")
-        self.assertEqual(to_unicode(returned[1]), "And I am 2. winning prize")
 
-    def test_stop_words_correctly_removed(self):
-        summarizer = TextRankSummarizer()
-        summarizer.stop_words = ["stop", "Halt", "SHUT", "HmMm"]
+def test_two_sentences():
+    document = build_document(("I am that 1. sentence", "And I am 2. winning prize"))
+    summarizer = TextRankSummarizer()
+    summarizer.stop_words = ("I", "am", "and", "that",)
 
-        document = build_document(
-            ("stop halt shut hmmm", "Stop Halt Shut Hmmm",),
-            ("StOp HaLt ShUt HmMm", "STOP HALT SHUT HMMM",),
-            ("Some relevant sentence", "Some moRe releVant sentEnce",),
-        )
-        sentences = document.sentences
+    returned = summarizer(document, 10)
+    assert len(returned) == 2
+    assert to_unicode(returned[0]) == "I am that 1. sentence"
+    assert to_unicode(returned[1]) == "And I am 2. winning prize"
 
-        expected = []
-        returned = summarizer._to_words_set(sentences[0])
-        self.assertEqual(expected, returned)
-        returned = summarizer._to_words_set(sentences[1])
-        self.assertEqual(expected, returned)
-        returned = summarizer._to_words_set(sentences[2])
-        self.assertEqual(expected, returned)
-        returned = summarizer._to_words_set(sentences[3])
-        self.assertEqual(expected, returned)
 
-        expected = ["some", "relevant", "sentence"]
-        returned = summarizer._to_words_set(sentences[4])
-        self.assertEqual(expected, returned)
-        expected = ["some", "more", "relevant", "sentence"]
-        returned = summarizer._to_words_set(sentences[5])
-        self.assertEqual(expected, returned)
+def test_stop_words_correctly_removed():
+    summarizer = TextRankSummarizer()
+    summarizer.stop_words = ["stop", "Halt", "SHUT", "HmMm"]
 
-    def test_sentences_rating(self):
-        document = build_document([
-            "a c e g",
-            "a b c d e f g",
-            "b d f",
-        ])
-        summarizer = TextRankSummarizer()
-        summarizer.stop_words = ["I", "am", "and", "that"]
+    document = build_document(
+        ("stop halt shut hmmm", "Stop Halt Shut Hmmm",),
+        ("StOp HaLt ShUt HmMm", "STOP HALT SHUT HMMM",),
+        ("Some relevant sentence", "Some moRe releVant sentEnce",),
+    )
+    sentences = document.sentences
 
-        ratings = summarizer.rate_sentences(document)
-        self.assertEqual(len(ratings), 3)
-        self.assertAlmostEqual(sum(ratings.values()), 1)
+    expected = []
+    returned = summarizer._to_words_set(sentences[0])
+    assert expected == returned
+    returned = summarizer._to_words_set(sentences[1])
+    assert expected == returned
+    returned = summarizer._to_words_set(sentences[2])
+    assert expected == returned
+    returned = summarizer._to_words_set(sentences[3])
+    assert expected == returned
+
+    expected = ["some", "relevant", "sentence"]
+    returned = summarizer._to_words_set(sentences[4])
+    assert expected == returned
+    expected = ["some", "more", "relevant", "sentence"]
+    returned = summarizer._to_words_set(sentences[5])
+    assert expected == returned
+
+
+def test_sentences_rating():
+    document = build_document([
+        "a c e g",
+        "a b c d e f g",
+        "b d f",
+    ])
+    summarizer = TextRankSummarizer()
+    summarizer.stop_words = ["I", "am", "and", "that"]
+
+    ratings = summarizer.rate_sentences(document)
+    assert len(ratings) == 3
+    assert pytest.approx(sum(ratings.values())) == 1


### PR DESCRIPTION
This PR fixes the TextRank algorithm so that it runs PageRank algorithm (as discussed in #87). This PR also:

- Adds `requirements.txt` file so contributors can install all the required dependencies easily. I don't know the exact version that you use, so maybe you can check if all the versions are correct.
- Updates pytest config section name in `setup.cfg` to `[tool:pytest]` instead of `[pytest]`; the latter is deprecated.
- Updates README by referencing the original TextRank paper. (I notice there is a README.rst file as well, why the redundancy? Github can parse .rst file just fine.)
- Fixes edge case when computing sentence similarity in TextRank. This guarantees the adjacency matrix has non-zero values in the diagonals, which makes more sense because a sentence should be similar to itself.

Some things to note:

- Current version of pytest does not seem to have pytest executable for every python version. I believe [tox](https://pypi.python.org/pypi/tox) is now the standard tool to do tests on several python versions.
- If this PR is accepted, `.travis.yml` file might be modified so it installs dependencies from `requirements.txt` so there's only one place where dependencies are listed.