### PR TITLE
Add support for ISO-639 language codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "docopt>=0.6.1,<0.7",
         "breadability>=0.1.20",
         "requests>=2.7.0",
-        "pycountry==18.2.23",
+        "pycountry>=18.2.23",
         "nltk>=3.0.2,<3.2.0" if VERSION_SUFFIX == "3.3" else "nltk>=3.0.2",  # NLTK 3.2 dropped support for Python 3.3
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "docopt>=0.6.1,<0.7",
         "breadability>=0.1.20",
         "requests>=2.7.0",
+        "pycountry==18.2.23",
         "nltk>=3.0.2,<3.2.0" if VERSION_SUFFIX == "3.3" else "nltk>=3.0.2",  # NLTK 3.2 dropped support for Python 3.3
     ],
     tests_require=[

--- a/sumy/__main__.py
+++ b/sumy/__main__.py
@@ -33,8 +33,7 @@ import sys
 
 from docopt import docopt
 from . import __version__
-from .utils import ItemsCount, get_stop_words, read_stop_words, fetch_url, \
-    normalize_language
+from .utils import ItemsCount, get_stop_words, read_stop_words, fetch_url
 from ._compat import to_string, to_unicode, to_bytes, PY3
 from .nlp.tokenizers import Tokenizer
 from .parsers.html import HtmlParser
@@ -102,7 +101,6 @@ def handle_arguments(args, default_input_stream=sys.stdin):
     items_count = ItemsCount(args["--length"])
 
     language = args["--language"]
-    language = normalize_language(language)
     if args['--stopwords']:
         stop_words = read_stop_words(args['--stopwords'])
     else:

--- a/sumy/__main__.py
+++ b/sumy/__main__.py
@@ -33,7 +33,8 @@ import sys
 
 from docopt import docopt
 from . import __version__
-from .utils import ItemsCount, get_stop_words, read_stop_words, fetch_url
+from .utils import ItemsCount, get_stop_words, read_stop_words, fetch_url, \
+    normalize_language
 from ._compat import to_string, to_unicode, to_bytes, PY3
 from .nlp.tokenizers import Tokenizer
 from .parsers.html import HtmlParser
@@ -101,6 +102,7 @@ def handle_arguments(args, default_input_stream=sys.stdin):
     items_count = ItemsCount(args["--length"])
 
     language = args["--language"]
+    language = normalize_language(language)
     if args['--stopwords']:
         stop_words = read_stop_words(args['--stopwords'])
     else:

--- a/sumy/nlp/stemmers/__init__.py
+++ b/sumy/nlp/stemmers/__init__.py
@@ -8,6 +8,7 @@ import nltk.stem.snowball as nltk_stemmers_module
 from .czech import stem_word as czech_stemmer
 
 from ..._compat import to_unicode
+from ...utils import normalize_language
 
 
 def null_stemmer(object):
@@ -24,6 +25,7 @@ class Stemmer(object):
     }
 
     def __init__(self, language):
+        language = normalize_language(language)
         self._stemmer = null_stemmer
         if language.lower() in self.SPECIAL_STEMMERS:
             self._stemmer = self.SPECIAL_STEMMERS[language.lower()]

--- a/sumy/nlp/tokenizers.py
+++ b/sumy/nlp/tokenizers.py
@@ -8,6 +8,7 @@ import zipfile
 import nltk
 
 from .._compat import to_string, to_unicode, unicode
+from ..utils import normalize_language
 
 
 class DefaultWordTokenizer(object):
@@ -61,6 +62,7 @@ class Tokenizer(object):
     }
 
     def __init__(self, language):
+        language = normalize_language(language)
         self._language = language
 
         tokenizer_language = self.LANGUAGE_ALIASES.get(language, language)

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -13,10 +13,25 @@ from os.path import dirname, abspath, join, exists
 from . import __version__
 from ._compat import to_string, to_unicode, string_types
 
+from pycountry import languages
+
 _HTTP_HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.155 Safari/537.36 OPR/31.0.1889.174",
     # "User-Agent": "Sumy (Automatic text summarizer) Version/%s" % __version__,
 }
+
+
+def normalize_language(language):
+    for lookup_key in ('alpha_2', 'alpha_3'):
+        try:
+            language = languages.get(**{lookup_key: language})
+        except KeyError:
+            continue
+        else:
+            language = language.name.lower()
+            break
+
+    return language
 
 
 def fetch_url(url):

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -63,6 +63,7 @@ def expand_resource_path(path):
 
 
 def get_stop_words(language):
+    language = normalize_language(language)
     try:
         stopwords_data = pkgutil.get_data("sumy", "data/stopwords/%s.txt" % language)
     except IOError as e:

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -22,7 +22,7 @@ _HTTP_HEADERS = {
 
 
 def normalize_language(language):
-    for lookup_key in ('alpha_2', 'alpha_3'):
+    for lookup_key in ("alpha_2", "alpha_3"):
         try:
             language = languages.get(**{lookup_key: language})
         except KeyError:

--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -25,11 +25,9 @@ def normalize_language(language):
     for lookup_key in ("alpha_2", "alpha_3"):
         try:
             language = languages.get(**{lookup_key: language})
+            return language.name.lower()
         except KeyError:
-            continue
-        else:
-            language = language.name.lower()
-            break
+            pass
 
     return language
 

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest
 
-from sumy.utils import get_stop_words, read_stop_words, ItemsCount
+from sumy.utils import get_stop_words, read_stop_words, ItemsCount, \
+    normalize_language
 from ..utils import expand_resource_path
 
 
@@ -69,3 +70,21 @@ def test_unsupported_items_count():
 
     with pytest.raises(ValueError):
         count([])
+
+
+def test_normalize_language_with_alpha_2_code():
+    assert normalize_language('fr') == 'french'
+    assert normalize_language('zh') == 'chinese'
+    assert normalize_language('sk') == 'slovak'
+
+
+def test_normalize_language_with_alpha_3_code():
+    assert normalize_language('fra') == 'french'
+    assert normalize_language('zho') == 'chinese'
+    assert normalize_language('slk') == 'slovak'
+
+
+def test_normalize_language_with_language_name():
+    assert normalize_language('french') == 'french'
+    assert normalize_language('chinese') == 'chinese'
+    assert normalize_language('slovak') == 'slovak'

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -73,18 +73,18 @@ def test_unsupported_items_count():
 
 
 def test_normalize_language_with_alpha_2_code():
-    assert normalize_language('fr') == 'french'
-    assert normalize_language('zh') == 'chinese'
-    assert normalize_language('sk') == 'slovak'
+    assert normalize_language("fr") == "french"
+    assert normalize_language("zh") == "chinese"
+    assert normalize_language("sk") == "slovak"
 
 
 def test_normalize_language_with_alpha_3_code():
-    assert normalize_language('fra') == 'french'
-    assert normalize_language('zho') == 'chinese'
-    assert normalize_language('slk') == 'slovak'
+    assert normalize_language("fra") == "french"
+    assert normalize_language("zho") == "chinese"
+    assert normalize_language("slk") == "slovak"
 
 
 def test_normalize_language_with_language_name():
-    assert normalize_language('french') == 'french'
-    assert normalize_language('chinese') == 'chinese'
-    assert normalize_language('slovak') == 'slovak'
+    assert normalize_language("french") == "french"
+    assert normalize_language("chinese") == "chinese"
+    assert normalize_language("slovak") == "slovak"


### PR DESCRIPTION
Currently, the language of the text to summarize has to be specified as a language name like "german" or "french". However, many tools such as Apache Tika output ISO-639 language codes which makes it difficult to integrate sumy with the wider natural language processing ecosystem.

This commit ensures that sumy can understand language codes passed as ISO-639, in both two-letter format (e.g. "de" or "fr") and three-letter format (e.g. "ger" or "fra").

Resolves https://github.com/miso-belica/sumy/issues/96