### PR TITLE
Allow words with dashes/apostrophe returned from tokenizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ matrix:
   include:
     - name: "Python 2.7 on Linux"
       python: 2.7
+      install:
+        - pip install -U pip wheel setuptools
+        - python setup.py install
+        # use "JPype1==0.7.1" (for kolnpy) because of Python 2 support
+        - pip install numpy tinysegmenter jieba "JPype1==0.7.1" konlpy
+        - python -c "import nltk; nltk.download('punkt')"
+        - pip install -U pytest codecov pytest-cov
     - name: "Python 3.5 on Linux"
       python: 3.5
     - name: "Python 3.6 on Linux"
@@ -51,7 +58,7 @@ before_install:
 install:
   - pip install -U pip wheel setuptools
   - python setup.py install
-  - pip install -U numpy tinysegmenter jieba konlpy
+  - pip install numpy tinysegmenter jieba konlpy
   - python -c "import nltk; nltk.download('punkt')"
   - pip install -U pytest codecov pytest-cov
 

--- a/sumy/nlp/tokenizers.py
+++ b/sumy/nlp/tokenizers.py
@@ -5,6 +5,7 @@ from __future__ import division, print_function, unicode_literals
 
 import re
 import zipfile
+
 import nltk
 
 from .._compat import to_string, to_unicode, unicode
@@ -34,6 +35,7 @@ class ChineseWordTokenizer:
             raise ValueError("Chinese tokenizer requires jieba. Please, install it by command 'pip install jieba'.")
         return jieba.cut(text)
 
+
 class KoreanSentencesTokenizer:
     def tokenize(self, text):
         try:
@@ -42,8 +44,8 @@ class KoreanSentencesTokenizer:
             raise ValueError("Korean tokenizer requires konlpy. Please, install it by command 'pip install konlpy'.")
         kkma = Kkma()
         return kkma.sentences(text)
-    
-    
+
+
 class KoreanWordTokenizer:
     def tokenize(self, text):
         try:
@@ -52,7 +54,7 @@ class KoreanWordTokenizer:
             raise ValueError("Korean tokenizer requires konlpy. Please, install it by command 'pip install konlpy'.")
         kkma = Kkma()
         return kkma.nouns(text)
-                
+
 
 class Tokenizer(object):
     """Language dependent tokenizer of text document."""
@@ -123,5 +125,6 @@ class Tokenizer(object):
         words = self._word_tokenizer.tokenize(to_unicode(sentence))
         return tuple(filter(self._is_word, words))
 
-    def _is_word(self, word):
+    @staticmethod
+    def _is_word(word):
         return bool(Tokenizer._WORD_PATTERN.search(word))

--- a/sumy/nlp/tokenizers.py
+++ b/sumy/nlp/tokenizers.py
@@ -59,7 +59,7 @@ class KoreanWordTokenizer:
 class Tokenizer(object):
     """Language dependent tokenizer of text document."""
 
-    _WORD_PATTERN = re.compile(r"^[^\W\d_]+$", re.UNICODE)
+    _WORD_PATTERN = re.compile(r"^[^\W\d_](?:[^\W\d_]|['-])*$", re.UNICODE)
     # feel free to contribute if you have better tokenizer for any of these languages :)
     LANGUAGE_ALIASES = {
         "slovak": "czech",
@@ -127,4 +127,4 @@ class Tokenizer(object):
 
     @staticmethod
     def _is_word(word):
-        return bool(Tokenizer._WORD_PATTERN.search(word))
+        return bool(Tokenizer._WORD_PATTERN.match(word))

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -34,15 +34,35 @@ def test_language_getter():
     assert "english" == tokenizer.language
 
 
-def test_tokenize_sentence():
-    tokenizer = Tokenizer("english")
-    words = tokenizer.to_words("I am a very nice sentence with comma, but..")
+@pytest.mark.parametrize("language, sentence, expected_words", [
+    (
+        "english",
+        "I am a very nice sentence with comma, but..",
+        ("I", "am", "a", "very", "nice", "sentence", "with", "comma"),
+    ),
+    (
+        "japanese",
+        "この文章を、正しくトークン化したい。",
+        ("この", "文章", "を", "正しく", "トークン", "化", "し", "たい"),
+    ),
+    (
+        "chinese",
+        "好用的文档自动化摘要程序",
+        ("好用", "的", "文档", "自动化", "摘要", "程序"),
+    ),
+    (
+        "korean",
+        "대학에서 DB, 통계학, 이산수학 등을 배웠지만...",
+        ("대학", "통계학", "이산", "이산수학", "수학", "등"),
+    ),
+])
+def test_tokenize_sentence_to_words(language, sentence, expected_words):
+    tokenizer = Tokenizer(language)
 
-    expected = (
-        "I", "am", "a", "very", "nice", "sentence",
-        "with", "comma",
-    )
-    assert expected == words
+    words = tokenizer.to_words(sentence)
+
+    assert words == expected_words
+    assert tokenizer.language == language
 
 
 def test_tokenize_sentences_with_abbreviations():
@@ -89,15 +109,6 @@ def test_slovak_alias_into_czech_tokenizer():
     assert expected == sentences
 
 
-def test_tokenize_japanese_sentence():
-    tokenizer = Tokenizer('japanese')
-    assert tokenizer.language == 'japanese'
-
-    sentence = 'この文章を、正しくトークン化したい。'
-    expected = ('この', '文章', 'を', '正しく', 'トークン', '化', 'し', 'たい')
-    assert expected == tokenizer.to_words(sentence)
-
-
 def test_tokenize_japanese_paragraph():
     tokenizer = Tokenizer('japanese')
     expected = (
@@ -107,15 +118,6 @@ def test_tokenize_japanese_paragraph():
     )
     paragraph = '１つ目の文章です。その次は何が来ますか？　「２つ目の文章」です。'
     assert expected == tokenizer.to_sentences(paragraph)
-
-
-def test_tokenize_chinese_sentence():
-    tokenizer = Tokenizer('chinese')
-    assert tokenizer.language == 'chinese'
-
-    sentence = '好用的文档自动化摘要程序。'
-    expected = ('好用', '的', '文档', '自动化', '摘要', '程序')
-    assert expected == tokenizer.to_words(sentence)
 
 
 def test_tokenize_chinese_paragraph():
@@ -128,15 +130,6 @@ def test_tokenize_chinese_paragraph():
 
     paragraph = '我正在为这个软件添加中文支持。这个软件是用于文档摘要！这个软件支持网页和文本两种输入格式？'
     assert expected == tokenizer.to_sentences(paragraph)
-
-
-def test_tokenize_korean_sentence():
-    tokenizer = Tokenizer('korean')
-    assert tokenizer.language == 'korean'
-
-    sentence = '대학에서 DB, 통계학, 이산수학 등을 배웠지만...'
-    expected = ('대학', '통계학', '이산', '이산수학', '수학', '등')
-    assert expected == tokenizer.to_words(sentence)
 
 
 def test_tokenize_korean_paragraph():

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -41,6 +41,11 @@ def test_language_getter():
         ("I", "am", "a", "very", "nice", "sentence", "with", "comma"),
     ),
     (
+        "english",
+        "I am doing sugar-free data-mining for Peter's study - vega punk.",
+        ("I", "am", "doing", "sugar-free", "data-mining", "for", "Peter", "study", "vega", "punk"),
+    ),
+    (
         "japanese",
         "この文章を、正しくトークン化したい。",
         ("この", "文章", "を", "正しく", "トークン", "化", "し", "たい"),

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
+
 import pytest
 
 from sumy.nlp.tokenizers import Tokenizer
@@ -55,10 +57,11 @@ def test_language_getter():
         "好用的文档自动化摘要程序",
         ("好用", "的", "文档", "自动化", "摘要", "程序"),
     ),
-    (
+    pytest.param(
         "korean",
         "대학에서 DB, 통계학, 이산수학 등을 배웠지만...",
         ("대학", "통계학", "이산", "이산수학", "수학", "등"),
+        marks=pytest.mark.skipif(sys.version_info < (3,), reason="JPype1 from konlpy does not support Python 2 anymore")
     ),
 ])
 def test_tokenize_sentence_to_words(language, sentence, expected_words):
@@ -137,6 +140,7 @@ def test_tokenize_chinese_paragraph():
     assert expected == tokenizer.to_sentences(paragraph)
 
 
+@pytest.mark.skipif(sys.version_info < (3,), reason="JPype1 from konlpy does not support Python 2 anymore")
 def test_tokenize_korean_paragraph():
     tokenizer = Tokenizer('korean')
     expected = (


### PR DESCRIPTION
This addresses some issues mentioned in https://github.com/miso-belica/sumy/issues/141.