### PR TITLE
Fix missing license in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
-include LICENSE.txt
+include LICENSE.md
 include CHANGELOG.md
 recursive-include sumy/data *
 recursive-exclude * __pycache__


### PR DESCRIPTION
This is due to the incorrect filename being listed in MANIFEST.in