### PR TITLE
avoid to add empty space between words and punctations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 .*
 !/.github/
 !.gitignore
+
+# do not import jupyter notebooks for exploration
+notebooks/

--- a/sumy/parsers/html.py
+++ b/sumy/parsers/html.py
@@ -8,6 +8,8 @@ from ..utils import cached_property, fetch_url
 from ..models.dom import Sentence, Paragraph, ObjectDocumentModel
 from .parser import DocumentParser
 
+from string import punctuation
+
 
 class HtmlParser(DocumentParser):
     """Parser of text from HTML format into DOM."""
@@ -93,7 +95,8 @@ class HtmlParser(DocumentParser):
                     sentences.append(Sentence(text, self._tokenizer, is_heading=True))
                 # skip <pre> nodes
                 elif not (annotations and "pre" in annotations):
-                    current_text += " " + text
+                    # be sure to not add empty space between word and punctations
+                    current_text += "" + text if text[0] in punctuation else " " + text
 
             new_sentences = self.tokenize_sentences(current_text)
             sentences.extend(Sentence(s, self._tokenizer) for s in new_sentences)

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -34,8 +34,7 @@ def test_from_url():
     LANG = "italian"
     parser = HtmlParser.from_url(url, Tokenizer(LANG))
     document = parser.document
-    test_str = "In informatica, il parsing, analisi sintattica o parsificazione è un processo che analizza un flusso continuo di dati in ingresso ( input, letti per esempio da un file o una tastiera) \
-        in modo da determinare la correttezza della sua struttura grazie ad una data grammatica formale."
+    test_str = "In informatica, il parsing, analisi sintattica o parsificazione è un processo che analizza un flusso continuo di dati in ingresso ( input, letti per esempio da un file o una tastiera) in modo da determinare la correttezza della sua struttura grazie ad una data grammatica formale."
 
     assert document.paragraphs[0].sentences[0]._text == test_str, "There should not be empty space between words and punctations."
 

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -30,11 +30,12 @@ def test_annotated_text():
     assert to_unicode(document.paragraphs[1].sentences[1]) == "Aj súbory majú predsa city."
 
 def test_from_url():
-    url = "https://it.wikipedia.org/wiki/Parsing"
-    LANG = "italian"
-    parser = HtmlParser.from_url(url, Tokenizer(LANG))
+    text = """
+    <p>In <a href="/wiki/Informatica" title="Informatica">informatica</a>, il <b>parsing</b>, 
+    <b>analisi sintattica</b> o <b>parsificazione</b> è un processo che analizza un flusso 
+    continuo di dati in ingresso ..."""
+    parser = HtmlParser.from_string(text, "https://it.wikipedia.org/wiki/Parsing", Tokenizer("italian"))
     document = parser.document
-    test_str = "In informatica, il parsing, analisi sintattica o parsificazione è un processo che analizza un flusso continuo di dati in ingresso ( input, letti per esempio da un file o una tastiera) in modo da determinare la correttezza della sua struttura grazie ad una data grammatica formale."
-
+    test_str = "In informatica, il parsing, analisi sintattica o parsificazione è un processo che analizza un flusso continuo di dati in ingresso ..." 
     assert document.paragraphs[0].sentences[0]._text == test_str, "There should not be empty space between words and punctations."
 

--- a/tests/test_html_parser.py
+++ b/tests/test_html_parser.py
@@ -28,3 +28,14 @@ def test_annotated_text():
 
     assert to_unicode(document.paragraphs[1].sentences[0]) == "Tento text je tu aby vyplnil prázdne miesto v srdci súboru."
     assert to_unicode(document.paragraphs[1].sentences[1]) == "Aj súbory majú predsa city."
+
+def test_from_url():
+    url = "https://it.wikipedia.org/wiki/Parsing"
+    LANG = "italian"
+    parser = HtmlParser.from_url(url, Tokenizer(LANG))
+    document = parser.document
+    test_str = "In informatica, il parsing, analisi sintattica o parsificazione è un processo che analizza un flusso continuo di dati in ingresso ( input, letti per esempio da un file o una tastiera) \
+        in modo da determinare la correttezza della sua struttura grazie ad una data grammatica formale."
+
+    assert document.paragraphs[0].sentences[0]._text == test_str, "There should not be empty space between words and punctations."
+


### PR DESCRIPTION
This small fix, avoid to add empty space between words and punctation symbols. I realized that there were annoying spaces in the final text. 