### PR TITLE
docs: Fix a few typos

### DIFF
--- a/sumy/models/tf.py
+++ b/sumy/models/tf.py
@@ -78,7 +78,7 @@ class TfDocumentModel(object):
             It may be viewed as a scaling down of TF by the largest TF
             value in document.
         :returns float:
-            0.0 <= frequency <= 1.0, where 0 means no occurence in document
+            0.0 <= frequency <= 1.0, where 0 means no occurrence in document
             and 1 the most frequent term in document.
         """
         frequency = self.term_frequency(term) / self._max_frequency

--- a/sumy/parsers/html.py
+++ b/sumy/parsers/html.py
@@ -95,7 +95,7 @@ class HtmlParser(DocumentParser):
                     sentences.append(Sentence(text, self._tokenizer, is_heading=True))
                 # skip <pre> nodes
                 elif not (annotations and "pre" in annotations):
-                    # be sure to not add empty space between word and punctations
+                    # be sure to not add empty space between word and punctuations
                     current_text += "" + text if text[0] in punctuation else " " + text
 
             new_sentences = self.tokenize_sentences(current_text)

--- a/sumy/summarizers/edmundson_cue.py
+++ b/sumy/summarizers/edmundson_cue.py
@@ -18,7 +18,7 @@ class EdmundsonCueMethod(AbstractSummarizer):
             stigma_word_weight)
 
     def _rate_sentence(self, sentence, bonus_word_weight, stigma_word_weight):
-        # count number of bonus/stigma words in sentece
+        # count number of bonus/stigma words in sentence
         words = map(self.stem_word, sentence.words)
         bonus_words_count, stigma_words_count = self._count_words(words)
 

--- a/sumy/summarizers/lsa.py
+++ b/sumy/summarizers/lsa.py
@@ -62,7 +62,7 @@ class LsaSummarizer(AbstractSummarizer):
     def _create_matrix(self, document, dictionary):
         """
         Creates matrix of shape |unique words|×|sentences| where cells
-        contains number of occurences of words (rows) in senteces (cols).
+        contains number of occurrences of words (rows) in sentences (cols).
         """
         sentences = document.sentences
 


### PR DESCRIPTION
There are small typos in:
- sumy/models/tf.py
- sumy/parsers/html.py
- sumy/summarizers/edmundson_cue.py
- sumy/summarizers/lsa.py

Fixes:
- Should read `sentences` rather than `senteces`.
- Should read `sentence` rather than `sentece`.
- Should read `punctuations` rather than `punctations`.
- Should read `occurrences` rather than `occurences`.
- Should read `occurrence` rather than `occurence`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md