### PR TITLE
Fixed bug with LexRank's power iteration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md") as readme:
 
 
 dependencies = [
-    "docopt>=0.6.1,<0.7",
+    "docopt-ng>=0.6.1",
     "breadability>=0.1.20",
     "requests>=2.7.0",
     "pycountry>=18.2.23",

--- a/sumy/summarizers/lex_rank.py
+++ b/sumy/summarizers/lex_rank.py
@@ -164,6 +164,7 @@ class LexRankSummarizer(AbstractSummarizer):
 
         while lambda_val > epsilon:
             next_p = numpy.dot(transposed_matrix, p_vector)
+            next_p /= numpy.linalg.norm(next_p)
             lambda_val = numpy.linalg.norm(numpy.subtract(next_p, p_vector))
             p_vector = next_p
 

--- a/tests/test_summarizers/test_lex_rank.py
+++ b/tests/test_summarizers/test_lex_rank.py
@@ -169,3 +169,16 @@ def test_power_method_should_return_different_scores_for_sentences():
     scores = LexRankSummarizer.power_method(matrix, LexRankSummarizer.epsilon)
 
     assert len(frozenset(scores.tolist())) > 1
+
+def test_power_method_should_return_finite():
+    """See https://github.com/miso-belica/sumy/issues/187"""
+    matrix = numpy.array([
+        [0.1, 0.2, 0.3, 0.6, 0.9],
+        [0.45, 0, 0.3, 0.6, 0],
+        [0.5, 0.6, 0.3, 1, 0.9],
+        [0.7, 0, 0, 0.6, 0],
+        [0.5, 0.123, 0, 0.111, 0.9],
+    ])
+    scores = LexRankSummarizer.power_method(matrix, LexRankSummarizer.epsilon)
+
+    assert all(numpy.isfinite(scores))


### PR DESCRIPTION
The `power_method` in `summarizers/lex_rank.py` was not correct. The `lambda_val` was increasing for [this test](https://github.com/miso-belica/sumy/blob/5f271e9679bfdd53d0680d47b3cdf1f0d2de5873/tests/test_summarizers/test_lex_rank.py#L160) and hence resulted in `inf` and `nan` values reported in #187 (also a warning would be raised when running that test).
The problem was that the `next_p` vector should have been normalized after the matrix multiplication according to [the Wikipedia entry](https://en.wikipedia.org/wiki/Power_iteration), which it was not.