### PR TITLE
Fixed `ItemsCount` to raise `ValueError`

### DIFF
--- a/sumy/utils.py
+++ b/sumy/utils.py
@@ -97,7 +97,7 @@ class ItemsCount(object):
         elif isinstance(self._value, (int, float)):
             return sequence[:int(self._value)]
         else:
-            ValueError("Unsuported value of items count '%s'." % self._value)
+            raise ValueError("Unsuported value of items count '%s'." % self._value)
 
     def __repr__(self):
         return to_string("<ItemsCount: %r>" % self._value)

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -56,6 +56,13 @@ def test_unsupported_items_count():
         count([])
 
 
+def test_items_count_with_unsupported_init_type():
+    count = ItemsCount([])
+
+    with pytest.raises(ValueError):
+        count([])
+
+
 def test_normalize_language_with_alpha_2_code():
     assert normalize_language("fr") == "french"
     assert normalize_language("zh") == "chinese"


### PR DESCRIPTION
When the value in `ItemsCount`'s constructor is not of a valid type, [this line](https://github.com/miso-belica/sumy/blob/230feaf7a960d95bd190a9ff3d741a729ce0a3a5/sumy/utils.py#L100) is supposed to raise a `ValueError`, but it does not.
This PR fixes that.