### PR TITLE
Fix KeyError in SumBasicSummarizer

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,17 @@
+Fix KeyError in SumBasic summarizer
+
+The _get_all_content_words_in_doc method was processing words in a
+different order (stem -> filter -> normalize) compared to
+_get_content_words_in_sentence (normalize -> filter -> stem). This
+mismatch meant some words would appear in the per-sentence word
+lists but not in the document frequency table, causing a KeyError
+during summarization.
+
+Aligned both methods to use the same processing order:
+normalize -> filter stop words -> stem.
+
+Also fixed _get_all_words_in_doc to return raw words instead of
+pre-stemmed words, since stemming is now handled consistently
+in _get_all_content_words_in_doc.
+
+Fixes #176

--- a/sumy/summarizers/sum_basic.py
+++ b/sumy/summarizers/sum_basic.py
@@ -28,7 +28,7 @@ class SumBasicSummarizer(AbstractSummarizer):
         return self._get_best_sentences(document.sentences, sentences_count, ratings)
 
     def _get_all_words_in_doc(self, sentences):
-        return self._stem_words([w for s in sentences for w in s.words])
+        return [w for s in sentences for w in s.words]
 
     def _get_content_words_in_sentence(self, sentence):
         normalized_words = self._normalize_words(sentence.words)
@@ -54,9 +54,10 @@ class SumBasicSummarizer(AbstractSummarizer):
 
     def _get_all_content_words_in_doc(self, sentences):
         all_words = self._get_all_words_in_doc(sentences)
-        content_words = self._filter_out_stop_words(all_words)
-        normalized_content_words = self._normalize_words(content_words)
-        return normalized_content_words
+        normalized_words = self._normalize_words(all_words)
+        content_words = self._filter_out_stop_words(normalized_words)
+        stemmed_content_words = self._stem_words(content_words)
+        return stemmed_content_words
 
     def _compute_tf(self, sentences):
         """


### PR DESCRIPTION
Fixes #176.

The `SumBasicSummarizer` crashes with a `KeyError` when processing certain texts because the word processing pipeline is inconsistent between two methods.

`_get_content_words_in_sentence` processes words in this order: **normalize → filter stop words → stem**

But `_get_all_content_words_in_doc` (via `_get_all_words_in_doc`) does it differently: **stem → filter stop words → normalize**

This means a word can end up in the per-sentence word list but be missing from the document frequency table (or vice versa), which causes the `KeyError` when looking up the word frequency.

The fix aligns `_get_all_content_words_in_doc` to follow the same processing order as `_get_content_words_in_sentence`: normalize → filter stop words → stem. `_get_all_words_in_doc` now returns raw (unstemmed) words so the caller can apply the pipeline consistently.

All existing sum_basic tests pass.
