### PR TITLE
Fix SumBasic KeyError by aligning word processing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **FIX:** Fixed `KeyError` in `SumBasicSummarizer` caused by inconsistent word processing order in https://github.com/miso-belica/sumy/pull/240
+
 ## 0.12.0 (2026-02-14)
 - **FEATURE:** Replace docopt with docopt-ng in https://github.com/miso-belica/sumy/pull/191
 - **FEATURE:** Add Swedish stopwords in https://github.com/miso-belica/sumy/pull/195

--- a/sumy/summarizers/sum_basic.py
+++ b/sumy/summarizers/sum_basic.py
@@ -28,10 +28,13 @@ class SumBasicSummarizer(AbstractSummarizer):
         return self._get_best_sentences(document.sentences, sentences_count, ratings)
 
     def _get_all_words_in_doc(self, sentences):
-        return self._stem_words([w for s in sentences for w in s.words])
+        return [w for s in sentences for w in s.words]
 
     def _get_content_words_in_sentence(self, sentence):
-        normalized_words = self._normalize_words(sentence.words)
+        return self._get_content_words(sentence.words)
+
+    def _get_content_words(self, words):
+        normalized_words = self._normalize_words(words)
         normalized_content_words = self._filter_out_stop_words(normalized_words)
         stemmed_normalized_content_words = self._stem_words(normalized_content_words)
         return stemmed_normalized_content_words
@@ -54,9 +57,7 @@ class SumBasicSummarizer(AbstractSummarizer):
 
     def _get_all_content_words_in_doc(self, sentences):
         all_words = self._get_all_words_in_doc(sentences)
-        content_words = self._filter_out_stop_words(all_words)
-        normalized_content_words = self._normalize_words(content_words)
-        return normalized_content_words
+        return self._get_content_words(all_words)
 
     def _compute_tf(self, sentences):
         """

--- a/tests/test_summarizers/test_sum_basic.py
+++ b/tests/test_summarizers/test_sum_basic.py
@@ -47,6 +47,29 @@ def test_stemmer_does_not_cause_crash():
     assert len(returned) == 1
 
 
+@pytest.mark.parametrize("stop_word, sentence_with_colliding_word", [
+    ("own", "He is owning a car."),
+    ("look", "She looked at the map."),
+])
+def test_key_error_when_stemmed_word_matches_stop_word(stop_word, sentence_with_colliding_word):
+    """https://github.com/miso-belica/sumy/issues/176
+
+    `_get_all_content_words_in_doc` stemmed words before filtering out stop
+    words, while `_get_content_words_in_sentence` filters before stemming.
+    A word whose stem collides with a stop word (e.g. "owning" -> "own",
+    "looked" -> "look") was therefore dropped from the document frequency
+    table but kept in a sentence's word list, causing a KeyError lookup.
+    """
+    summarizer = _build_summarizer([stop_word], Stemmer("english"))
+    document = build_document([
+        Sentence(sentence_with_colliding_word, Tokenizer("english")),
+        Sentence("He drives to the store.", Tokenizer("english")),
+    ])
+
+    returned = summarizer(document, 2)
+    assert len(returned) == 2
+
+
 def test_normalize_words():
     summarizer = _build_summarizer(EMPTY_STOP_WORDS)
     sentence = "This iS A test 2 CHECk normalization."


### PR DESCRIPTION
The review comments in https://github.com/miso-belica/sumy/pull/234 were not addressed so this is a clean fix with a repro tests from https://github.com/miso-belica/sumy/issues/176

Fixes #176 and closes #234